### PR TITLE
fix(feishu): support native table rendering in interactive cards

### DIFF
--- a/src/main/apps/feishu/bot.service.ts
+++ b/src/main/apps/feishu/bot.service.ts
@@ -857,6 +857,74 @@ export class FeishuBotService {
     }
   }
 
+  private buildCardElements(markdown: string): object[] {
+    const lines = markdown.split('\n')
+    const elements: object[] = []
+    let textBuffer: string[] = []
+    let i = 0
+
+    const flushText = () => {
+      const text = textBuffer.join('\n').trim()
+      if (text) {
+        elements.push({ tag: 'markdown', content: text })
+      }
+      textBuffer = []
+    }
+
+    while (i < lines.length) {
+      const line = lines[i]
+
+      if (/^\|.+\|$/.test(line.trim())) {
+        // Collect all consecutive table lines
+        const tableLines: string[] = []
+        while (i < lines.length && /^\|.+\|$/.test(lines[i].trim())) {
+          tableLines.push(lines[i])
+          i++
+        }
+
+        // Need at least header + separator + 1 data row
+        if (tableLines.length < 3) {
+          textBuffer.push(...tableLines)
+          continue
+        }
+
+        // Parse headers (first row), strip markdown bold syntax
+        const headers = tableLines[0]
+          .split('|')
+          .filter(cell => cell.trim() !== '')
+          .map(cell => cell.trim().replace(/\*\*/g, ''))
+
+        // Use indexed internal keys to avoid special chars in column names
+        // display_name shows the actual header text to the user
+        const colKeys = headers.map((_, idx) => `col_${idx}`)
+
+        // Parse data rows (skip separator row at index 1), strip markdown bold syntax
+        const rows = tableLines.slice(2).map(row => {
+          const cells = row.split('|').filter(cell => cell.trim() !== '').map(cell => cell.trim().replace(/\*\*/g, ''))
+          return Object.fromEntries(colKeys.map((key, idx) => [key, cells[idx] ?? '']))
+        })
+
+        flushText()
+        const tableElement = {
+          tag: 'table',
+          columns: headers.map((displayName, idx) => ({
+            name: colKeys[idx],
+            display_name: displayName,
+            data_type: 'text'
+          })),
+          rows
+        }
+        elements.push(tableElement)
+      } else {
+        textBuffer.push(line)
+        i++
+      }
+    }
+
+    flushText()
+    return elements
+  }
+
   /**
    * Send a markdown message using interactive card
    * This provides better formatting for Agent responses
@@ -871,17 +939,23 @@ export class FeishuBotService {
     }
 
     try {
-      // Build card with markdown content
-      const card = {
+      // Extract first heading from markdown as card title
+      const headingMatch = markdown.match(/^#{1,3}\s+(.+)$/m)
+      const cardTitle = headingMatch ? headingMatch[1].trim() : undefined
+
+      // Build card with markdown content, converting any markdown tables to native Feishu tables
+      const card: Record<string, unknown> = {
         config: {
           wide_screen_mode: true
         },
-        elements: [
-          {
-            tag: 'markdown',
-            content: markdown
-          }
-        ]
+        elements: this.buildCardElements(markdown)
+      }
+
+      if (cardTitle) {
+        card.header = {
+          title: { tag: 'plain_text', content: cardTitle },
+          template: 'blue'
+        }
       }
 
       const response = await this.client.im.message.create({

--- a/src/main/tools/feishu.definitions.ts
+++ b/src/main/tools/feishu.definitions.ts
@@ -57,7 +57,7 @@ export const feishuTools: Anthropic.Tool[] = [
   {
     name: 'feishu_send_card',
     description:
-      'Send an interactive message card to the current Feishu chat. Cards support rich formatting.',
+      'Send an interactive message card to the current Feishu chat. Cards support rich formatting. IMPORTANT: When presenting tabular/comparison data, use the rows field instead of markdown tables in content — Feishu will render a native table.',
     input_schema: {
       type: 'object',
       properties: {
@@ -67,7 +67,14 @@ export const feishuTools: Anthropic.Tool[] = [
         },
         content: {
           type: 'string',
-          description: 'Card content (markdown supported)'
+          description: 'Card content (markdown supported). Do NOT use | table | syntax here.'
+        },
+        rows: {
+          type: 'array',
+          description: 'Optional: Table data. When provided, renders a native Feishu table. Each object key is a column header, value is cell content. IMPORTANT: Keys MUST be meaningful column names (e.g. "方法", "用途", "场景"). NEVER use "--" or "---" as keys. Example: [{"名称":"GET","用途":"获取资源","是否有请求体":"否"}]',
+          items: {
+            type: 'object'
+          }
         },
         template: {
           type: 'string',

--- a/src/main/tools/feishu.executor.ts
+++ b/src/main/tools/feishu.executor.ts
@@ -190,12 +190,45 @@ interface SendCardInput {
   title: string
   content: string
   template?: string
+  rows?: Record<string, string>[]
 }
 
 export async function executeFeishuSendCard(input: SendCardInput): Promise<ToolResult> {
   const chatId = getCurrentChatId()
   if (!chatId) {
     return { success: false, error: 'No active Feishu chat. User must send a message first.' }
+  }
+
+  // If rows are provided but all keys are '--'/'---', the LLM didn't provide meaningful column names.
+  // Skip the entire tool call and let buildCardElements handle it via Final Response markdown instead.
+  if (input.rows && input.rows.length > 0) {
+    const columns = Object.keys(input.rows[0])
+    const allPlaceholder = columns.every(col => /^-+$/.test(col.trim()))
+    if (allPlaceholder) {
+      return { success: true, data: { skipped: true } }
+    }
+  }
+
+  const elements: object[] = []
+
+  if (input.content) {
+    elements.push({ tag: 'markdown', content: input.content })
+  }
+
+  if (input.rows && input.rows.length > 0) {
+    const displayNames = Object.keys(input.rows[0])
+    const colKeys = displayNames.map((_, idx) => `col_${idx}`)
+    elements.push({
+      tag: 'table',
+      columns: displayNames.map((displayName, idx) => ({
+        name: colKeys[idx],
+        display_name: displayName,
+        data_type: 'text'
+      })),
+      rows: input.rows.map(row =>
+        Object.fromEntries(displayNames.map((displayName, idx) => [colKeys[idx], row[displayName] ?? '']))
+      )
+    })
   }
 
   const card = {
@@ -206,12 +239,7 @@ export async function executeFeishuSendCard(input: SendCardInput): Promise<ToolR
       },
       template: input.template || 'blue'
     },
-    elements: [
-      {
-        tag: 'markdown',
-        content: input.content
-      }
-    ]
+    elements
   }
 
   const result = await feishuBotService.sendCard(chatId, card as any)


### PR DESCRIPTION
## What does this PR do?
- 新增 `buildCardElements` 方法，自动将 markdown 表格转换为飞书原生 table 组件
- 使用 `display_name` 字段显示列标题，解决列名显示 `--` 的问题
- `feishu_send_card` 工具新增 `rows` 字段，支持 LLM 直接传入表格数据

## Why is this change needed?
飞书卡片的 markdown 元素不支持表格语法，导致 LLM 返回的表格内容无法正确渲染，列名显示为 `--`。通过将 markdown 表格自动转换为飞书原生 table 组件并使用 `display_name` 字段，实现正确的表格渲染。

## Type of Change
- New feature

## Screenshot
<img width="624" height="497" alt="image" src="https://github.com/user-attachments/assets/88acccdf-e5fe-4322-958b-e5a1d2c8594c" />

 