### PR TITLE
feat(llm): add Gemini provider and OpenAI/Gemini format support for C…

### DIFF
--- a/src/main/config/settings.config.ts
+++ b/src/main/config/settings.config.ts
@@ -8,7 +8,7 @@ const SETTINGS_FILE = 'settings.json'
 /**
  * LLM Provider type
  */
-export type LLMProvider = 'claude' | 'minimax' | 'zenmux' | 'ollama' | 'openai' | 'custom' 
+export type LLMProvider = 'claude' | 'minimax' | 'zenmux' | 'ollama' | 'openai' | 'gemini' | 'custom'
 
 /**
  * Provider configurations
@@ -43,6 +43,11 @@ export const PROVIDER_CONFIGS: Record<LLMProvider, { name: string; baseUrl: stri
     name: 'OpenAI',
     baseUrl: 'https://api.openai.com/v1',
     defaultModel: 'gpt-4o'
+  },
+  gemini: {
+    name: 'Google Gemini',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    defaultModel: 'gemini-2.0-flash'
   }
 }
 
@@ -75,10 +80,15 @@ export interface AppSettings {
   openaiBaseUrl: string;
   openaiModel: string;
   
+  // Gemini settings
+  geminiApiKey: string
+  geminiModel: string
+
   // Custom provider settings
   customApiKey: string
   customBaseUrl: string
   customModel: string
+  customApiFormat: 'anthropic' | 'openai' | 'gemini'
   
   // Shared LLM settings
   maxTokens: number
@@ -174,10 +184,15 @@ const DEFAULT_SETTINGS: AppSettings = {
   openaiBaseUrl: 'https://api.openai.com/v1',
   openaiModel: 'gpt-4o',
   
+  // Gemini settings
+  geminiApiKey: '',
+  geminiModel: 'gemini-2.0-flash',
+
   // Custom provider settings
   customApiKey: '',
   customBaseUrl: '',
   customModel: '',
+  customApiFormat: 'anthropic',
   
   // Shared LLM settings
   maxTokens: 8192,
@@ -377,6 +392,13 @@ class SettingsManager {
             model: this.settings.openaiModel || 'gpt-4o',
             provider
           }
+      case 'gemini':
+        return {
+          apiKey: this.settings.geminiApiKey,
+          baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+          model: this.settings.geminiModel || 'gemini-2.0-flash',
+          provider
+        }
       case 'custom':
         return {
           apiKey: this.settings.customApiKey,

--- a/src/main/services/agent.service.ts
+++ b/src/main/services/agent.service.ts
@@ -1293,7 +1293,8 @@ export class AgentService {
           }
           
           response = betaResponse as unknown as Anthropic.Message
-        } if (provider === 'ollama' || provider === 'openai') {
+        } else if (provider === 'ollama' || provider === 'openai' || provider === 'gemini' ||
+          (provider === 'custom' && (settings.customApiFormat === 'openai' || settings.customApiFormat === 'gemini'))) {
           // 由于非 Claude 分支，这里沿用作者原本的压缩老旧 Tool Result 逻辑
           const compacted = await compactToolResults(this.conversationHistory)
           if (compacted > 0) {
@@ -1605,6 +1606,7 @@ export class AgentService {
 
       // Create client
       const { client, model, maxTokens, provider } = await createClient()
+      const settings = await loadSettings()
 
       // Build the evaluation prompt
       const evaluationPrompt = this.buildEvaluationPrompt(context, data)
@@ -1635,7 +1637,8 @@ IMPORTANT: Respond with ONLY the JSON object, no additional text.`
 
       let textContent: Anthropic.TextBlock | undefined;
 
-      if (provider === 'ollama' || provider === 'openai') {
+      if (provider === 'ollama' || provider === 'openai' || provider === 'gemini' ||
+          (provider === 'custom' && (settings.customApiFormat === 'openai' || settings.customApiFormat === 'gemini'))) {
         const response = await runOpenAIAdapter(
           client as OpenAI,
           model,

--- a/src/main/services/agent/utils.ts
+++ b/src/main/services/agent/utils.ts
@@ -54,10 +54,18 @@ export async function createClient(): Promise<{ client: Anthropic | OpenAI; mode
       baseURL = settings.openaiBaseUrl || 'https://api.openai.com/v1'
       model = settings.openaiModel || 'gpt-4o'
       return { client: new OpenAI({ apiKey, baseURL }), model, maxTokens: settings.maxTokens, provider }
+    case 'gemini':
+      apiKey = settings.geminiApiKey
+      baseURL = 'https://generativelanguage.googleapis.com/v1beta/openai'
+      model = settings.geminiModel || 'gemini-2.0-flash'
+      return { client: new OpenAI({ apiKey, baseURL }), model, maxTokens: settings.maxTokens, provider }
     case 'custom':
       apiKey = settings.customApiKey
       baseURL = settings.customBaseUrl || undefined
       model = settings.customModel
+      if (settings.customApiFormat === 'openai' || settings.customApiFormat === 'gemini') {
+        return { client: new OpenAI({ apiKey, baseURL }), model, maxTokens: settings.maxTokens, provider }
+      }
       break
     default:
       apiKey = settings.claudeApiKey

--- a/src/renderer/src/components/Settings/GeneralSettings.tsx
+++ b/src/renderer/src/components/Settings/GeneralSettings.tsx
@@ -50,10 +50,14 @@ export function GeneralSettings(): JSX.Element {
     // Zenmux settings
     settings.zenmuxApiKey !== originalSettings.zenmuxApiKey ||
     settings.zenmuxModel !== originalSettings.zenmuxModel ||
+    // Gemini settings
+    settings.geminiApiKey !== originalSettings.geminiApiKey ||
+    settings.geminiModel !== originalSettings.geminiModel ||
     // Custom provider settings
     settings.customApiKey !== originalSettings.customApiKey ||
     settings.customBaseUrl !== originalSettings.customBaseUrl ||
     settings.customModel !== originalSettings.customModel ||
+    settings.customApiFormat !== originalSettings.customApiFormat ||
     // Ollama settings
     settings.ollamaApiKey !== originalSettings.ollamaApiKey ||
     settings.ollamaBaseUrl !== originalSettings.ollamaBaseUrl ||
@@ -97,10 +101,14 @@ export function GeneralSettings(): JSX.Element {
         openaiApiKey: settings.openaiApiKey,
         openaiBaseUrl: settings.openaiBaseUrl,
         openaiModel: settings.openaiModel,
+        // Gemini settings
+        geminiApiKey: settings.geminiApiKey,
+        geminiModel: settings.geminiModel,
         // Custom provider settings
         customApiKey: settings.customApiKey,
         customBaseUrl: settings.customBaseUrl,
         customModel: settings.customModel,
+        customApiFormat: settings.customApiFormat,
         // Other settings
         memuApiKey: settings.memuApiKey,
         language: settings.language,
@@ -310,14 +318,52 @@ export function GeneralSettings(): JSX.Element {
             </div>
           )}
 
+          {/* Gemini Settings */}
+          {settings.llmProvider === 'gemini' && (
+            <div className="space-y-3 p-3 rounded-xl bg-blue-500/5 border border-blue-500/20">
+              <div>
+                <label className="text-[11px] text-[var(--text-muted)] mb-1 block">API Key</label>
+                <input
+                  type="password"
+                  placeholder="AIza..."
+                  value={settings.geminiApiKey || ''}
+                  onChange={(e) => setSettings({ ...settings, geminiApiKey: e.target.value })}
+                  className="w-full px-3 py-2.5 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] placeholder-[var(--text-placeholder)] focus:outline-none focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/10 transition-all"
+                />
+              </div>
+              <div>
+                <label className="text-[11px] text-[var(--text-muted)] mb-1 block">Model Name</label>
+                <input
+                  type="text"
+                  placeholder="gemini-2.0-flash"
+                  value={settings.geminiModel || ''}
+                  onChange={(e) => setSettings({ ...settings, geminiModel: e.target.value })}
+                  className="w-full px-3 py-2.5 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] placeholder-[var(--text-placeholder)] focus:outline-none focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/10 transition-all"
+                />
+              </div>
+            </div>
+          )}
+
           {/* Custom Provider Settings */}
           {settings.llmProvider === 'custom' && (
             <div className="space-y-3 p-3 rounded-xl bg-purple-500/5 border border-purple-500/20">
               <div>
+                <label className="text-[11px] text-[var(--text-muted)] mb-1 block">API Format</label>
+                <select
+                  value={settings.customApiFormat || 'anthropic'}
+                  onChange={(e) => setSettings({ ...settings, customApiFormat: e.target.value as 'anthropic' | 'openai' | 'gemini' })}
+                  className="w-full px-3 py-2.5 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] focus:outline-none focus:border-purple-500/50 focus:ring-2 focus:ring-purple-500/10 transition-all"
+                >
+                  <option value="anthropic">Anthropic</option>
+                  <option value="openai">OpenAI</option>
+                  <option value="gemini">Gemini</option>
+                </select>
+              </div>
+              <div>
                 <label className="text-[11px] text-[var(--text-muted)] mb-1 block">{t('settings.llm.baseUrl')}</label>
                 <input
                   type="text"
-                  placeholder="https://api.example.com/anthropic"
+                  placeholder="https://api.example.com/v1"
                   value={settings.customBaseUrl || ''}
                   onChange={(e) => setSettings({ ...settings, customBaseUrl: e.target.value })}
                   className="w-full px-3 py-2.5 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] placeholder-[var(--text-placeholder)] focus:outline-none focus:border-purple-500/50 focus:ring-2 focus:ring-purple-500/10 transition-all"

--- a/src/renderer/src/components/Settings/shared.tsx
+++ b/src/renderer/src/components/Settings/shared.tsx
@@ -3,7 +3,7 @@ import { Loader2, Check, AlertCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 // LLM Provider type
-export type LLMProvider = 'claude' | 'minimax' | 'zenmux' | 'ollama' | 'openai' | 'custom'
+export type LLMProvider = 'claude' | 'minimax' | 'zenmux' | 'ollama' | 'openai' | 'gemini' | 'custom'
 
 // Provider options for select
 export const PROVIDER_OPTIONS: { value: LLMProvider; label: string }[] = [
@@ -12,6 +12,7 @@ export const PROVIDER_OPTIONS: { value: LLMProvider; label: string }[] = [
   { value: 'minimax', label: 'MiniMax' },
   { value: 'ollama', label: 'Ollama' },
   { value: 'openai', label: 'OpenAI' },
+  { value: 'gemini', label: 'Google Gemini' },
   { value: 'custom', label: 'Custom Provider' }
 ]
 
@@ -36,10 +37,14 @@ export interface AppSettings {
   openaiApiKey: string
   openaiBaseUrl: string
   openaiModel: string
+  // Gemini settings
+  geminiApiKey: string
+  geminiModel: string
   // Custom provider settings
   customApiKey: string
   customBaseUrl: string
   customModel: string
+  customApiFormat: 'anthropic' | 'openai' | 'gemini'
   // Shared settings
   maxTokens: number
   temperature: number


### PR DESCRIPTION
## What does this PR do?

- Add **Google Gemini** as a dedicated LLM provider option, using its OpenAI-compatible endpoint
- Add **API Format selector** to Custom Provider (Anthropic / OpenAI / Gemini), enabling integration with any third-party API that follows one of these formats
- Fix a bug in `agent.service.ts` where a missing `else` caused the Claude branch to fall through into other provider branches

## Why is this change needed?

Previously, the Custom Provider only supported Anthropic-format APIs, making it impossible to connect to third-party services that expose OpenAI or Gemini-compatible interfaces. With the new format selector, users can flexibly configure any compatible API endpoint. Google Gemini is also added as a first-class provider for users who prefer it directly.

## Type of Change

- [x] New feature
- [x] Bug fix

## Screenshot
<img width="630" height="323" alt="image" src="https://github.com/user-attachments/assets/f49b232e-d54f-4c98-bcc4-5eac04ad8403" />
<img width="619" height="315" alt="image" src="https://github.com/user-attachments/assets/fcb0278a-1891-4020-8786-d50dfbcdc2dd" />
