### PR TITLE
fix: truncate long MCP server option text to prevent button overflow

### DIFF
--- a/src/renderer/src/components/Settings/McpSettings.tsx
+++ b/src/renderer/src/components/Settings/McpSettings.tsx
@@ -412,12 +412,12 @@ export function McpSettings(): JSX.Element {
                 className="flex items-center justify-between p-4 cursor-pointer hover:bg-[var(--bg-card)]"
                 onClick={() => setExpandedServer(expandedServer === server.name ? null : server.name)}
               >
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
                   {(() => {
                     const status = getServerStatus(server.name)
                     const isConnected = status?.connected
                     return (
-                      <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                      <div className={`w-8 h-8 rounded-lg flex-shrink-0 flex items-center justify-center ${
                         !server.enabled 
                           ? 'bg-[var(--bg-input)] text-[var(--text-muted)]'
                           : isConnected
@@ -428,7 +428,7 @@ export function McpSettings(): JSX.Element {
                       </div>
                     )
                   })()}
-                  <div>
+                  <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <h4 className="text-[13px] font-medium text-[var(--text-primary)]">
                         {server.name}
@@ -451,12 +451,12 @@ export function McpSettings(): JSX.Element {
                         return null
                       })()}
                     </div>
-                    <p className="text-[11px] text-[var(--text-muted)]">
+                    <p className="text-[11px] text-[var(--text-muted)] truncate">
                       {server.command} {server.args.join(' ')}
                     </p>
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-shrink-0">
                   <button
                     onClick={(e) => {
                       e.stopPropagation()


### PR DESCRIPTION
## Summary
- Fix MCP settings UI bug where long command+args strings push action buttons (toggle, delete, expand) off-screen

## Problem
When an MCP server's command + arguments string is very long, the text overflows the available space in the server header row, pushing the right-side action buttons out of view.

![Bug Screenshot](/Users/teio/Pictures/20260312-191517.png)

## Changes
- Added `min-w-0` and `flex-1` to the left content container so it respects flex layout constraints
- Added `flex-shrink-0` to the server status icon to prevent it from shrinking
- Added `min-w-0` to the text wrapper div to enable proper text truncation
- Added `truncate` (Tailwind) to the command+args paragraph to ellipsize overflowing text
- Added `flex-shrink-0` to the right button group to ensure buttons always remain visible

## Test Plan
- [ ] Add an MCP server with a very long command+args string
- [ ] Verify the text is truncated with ellipsis
- [ ] Verify action buttons (stop/start, delete, expand) remain visible and clickable
- [ ] Verify normal-length server entries still display correctly