### PR TITLE
feat: add local chat with persisted history and tool access safeguards

### DIFF
--- a/src/main/apps/discord/bot.service.ts
+++ b/src/main/apps/discord/bot.service.ts
@@ -450,7 +450,10 @@ export class DiscordBotService {
       }
 
       // Get response from Agent with Discord-specific tools
-      const response = await agentService.processMessage(fullMessage, 'discord', imageUrls)
+      const response = await agentService.processMessage(fullMessage, 'discord', imageUrls, undefined, {
+        source: 'message',
+        userId: originalMessage.author.id
+      })
 
       // Check if rejected due to processing lock
       if (!response.success && response.busyWith) {

--- a/src/main/apps/feishu/bot.service.ts
+++ b/src/main/apps/feishu/bot.service.ts
@@ -403,7 +403,7 @@ export class FeishuBotService {
 
     // Process with Agent
     if ((agentMessage || imageUrls.length > 0) && this.client) {
-      await this.processWithAgentAndReply(chatId, agentMessage, imageUrls)
+      await this.processWithAgentAndReply(chatId, senderId, agentMessage, imageUrls)
     }
   }
 
@@ -667,6 +667,7 @@ export class FeishuBotService {
    */
   private async processWithAgentAndReply(
     chatId: string,
+    userId: string,
     userMessage: string,
     imageUrls: string[] = []
   ): Promise<void> {
@@ -681,7 +682,10 @@ export class FeishuBotService {
         return
       }
 
-      const response = await agentService.processMessage(userMessage, 'feishu', imageUrls, chatId)
+      const response = await agentService.processMessage(userMessage, 'feishu', imageUrls, chatId, {
+        source: 'message',
+        userId
+      })
 
       // Check if rejected due to processing lock
       if (!response.success && response.busyWith) {

--- a/src/main/apps/line/bot.service.ts
+++ b/src/main/apps/line/bot.service.ts
@@ -157,7 +157,7 @@ export class LineBotService {
 
     // Process with Agent
     if (text && event.replyToken) {
-      await this.processWithAgentAndReply(event.replyToken, sourceType, sourceId, text)
+      await this.processWithAgentAndReply(event.replyToken, sourceType, sourceId, userId, text)
     }
   }
 
@@ -168,6 +168,7 @@ export class LineBotService {
     replyToken: string,
     sourceType: 'user' | 'group' | 'room',
     sourceId: string,
+    userId: string,
     userMessage: string
   ): Promise<void> {
     console.log('[Line] Sending to Agent:', userMessage.substring(0, 50) + '...')
@@ -179,7 +180,10 @@ export class LineBotService {
         return
       }
 
-      const response = await agentService.processMessage(userMessage, 'line')
+      const response = await agentService.processMessage(userMessage, 'line', [], undefined, {
+        source: 'message',
+        userId
+      })
 
       // Check if rejected due to processing lock
       if (!response.success && response.busyWith) {

--- a/src/main/apps/local/index.ts
+++ b/src/main/apps/local/index.ts
@@ -1,0 +1,3 @@
+export { localChatService, LocalChatService } from './local.service'
+export { localStorage, LocalStorage } from './storage'
+export * from './types'

--- a/src/main/apps/local/local.service.ts
+++ b/src/main/apps/local/local.service.ts
@@ -1,0 +1,157 @@
+import { agentService } from '../../services/agent.service'
+import { infraService } from '../../services/infra.service'
+import { appEvents } from '../../events'
+import type { AppMessage, BotStatus } from '../types'
+import { localStorage } from './storage'
+import type { StoredLocalMessage } from './types'
+
+const DEFAULT_SESSION_ID = 'default'
+const LOCAL_BOT_NAME = 'memU bot'
+const LOCAL_USER_NAME = 'You'
+
+function createMessageId(prefix: 'user' | 'assistant'): string {
+  return `local-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export class LocalChatService {
+  readonly platform = 'local' as const
+  private readonly status: BotStatus = {
+    platform: 'local',
+    isConnected: true,
+    botName: LOCAL_BOT_NAME
+  }
+  private initialized = false
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+    await localStorage.initialize()
+    appEvents.emitLocalStatusChanged(this.status)
+    this.initialized = true
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.initialize()
+    }
+  }
+
+  getStatus(): BotStatus {
+    return this.status
+  }
+
+  async getMessages(limit?: number, sessionId = DEFAULT_SESSION_ID): Promise<AppMessage[]> {
+    await this.ensureInitialized()
+    const messages = await localStorage.getMessages(limit, sessionId)
+    return messages.map((message) => this.toAppMessage(message))
+  }
+
+  async clearMessages(sessionId = DEFAULT_SESSION_ID): Promise<void> {
+    await this.ensureInitialized()
+    await localStorage.clearMessages(sessionId)
+    agentService.invalidateContextForPlatform('local')
+    appEvents.emitMessagesRefresh('local')
+  }
+
+  async sendMessage(content: string, sessionId = DEFAULT_SESSION_ID): Promise<{ success: boolean; data?: AppMessage; error?: string }> {
+    await this.ensureInitialized()
+
+    const trimmed = content.trim()
+    if (!trimmed) {
+      return { success: false, error: 'Message cannot be empty' }
+    }
+
+    const userMessage = await this.storeAndEmitMessage({
+      messageId: createMessageId('user'),
+      sessionId,
+      text: trimmed,
+      date: Math.floor(Date.now() / 1000),
+      isFromBot: false
+    })
+
+    infraService.publish('message:incoming', {
+      platform: 'local',
+      timestamp: Math.floor(Date.now() / 1000),
+      message: { role: 'user', content: trimmed },
+      metadata: {
+        chatId: sessionId,
+        messageId: userMessage.id,
+        source: 'local-ui'
+      }
+    })
+
+    const wasConsumed = await infraService.tryConsumeUserInput(trimmed, 'local')
+    if (wasConsumed) {
+      return { success: true, data: userMessage }
+    }
+
+    const response = await agentService.processMessage(trimmed, 'local', [], sessionId, {
+      source: 'message',
+      isAuthorizedUser: true,
+      userId: 'local-user'
+    })
+
+    if (response.message) {
+      await this.sendBotMessage(response.message, sessionId, userMessage.id)
+    }
+
+    if (!response.success && !response.message) {
+      return { success: false, error: response.error || 'Failed to process local message' }
+    }
+
+    return { success: true, data: userMessage }
+  }
+
+  async sendBotMessage(
+    content: string,
+    sessionId = DEFAULT_SESSION_ID,
+    replyToId?: string
+  ): Promise<AppMessage> {
+    await this.ensureInitialized()
+
+    const storedMessage: StoredLocalMessage = {
+      messageId: createMessageId('assistant'),
+      sessionId,
+      text: content,
+      date: Math.floor(Date.now() / 1000),
+      isFromBot: true,
+      replyToMessageId: replyToId
+    }
+
+    const appMessage = await this.storeAndEmitMessage(storedMessage)
+    infraService.publish('message:outgoing', {
+      platform: 'local',
+      timestamp: storedMessage.date,
+      message: { role: 'assistant', content },
+      metadata: {
+        messageId: storedMessage.messageId,
+        replyToId
+      }
+    })
+
+    return appMessage
+  }
+
+  private async storeAndEmitMessage(message: StoredLocalMessage): Promise<AppMessage> {
+    await localStorage.storeMessage(message)
+    const appMessage = this.toAppMessage(message)
+    appEvents.emitLocalNewMessage(appMessage)
+    return appMessage
+  }
+
+  private toAppMessage(message: StoredLocalMessage): AppMessage {
+    return {
+      id: message.messageId,
+      platform: 'local',
+      chatId: message.sessionId,
+      senderId: message.isFromBot ? 'local-bot' : 'local-user',
+      senderName: message.isFromBot ? LOCAL_BOT_NAME : LOCAL_USER_NAME,
+      content: message.text,
+      timestamp: new Date(message.date * 1000),
+      isFromBot: message.isFromBot,
+      replyToId: message.replyToMessageId,
+      metadata: message.metadata
+    }
+  }
+}
+
+export const localChatService = new LocalChatService()

--- a/src/main/apps/local/storage.ts
+++ b/src/main/apps/local/storage.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { app } from 'electron'
+import type { StoredLocalMessage } from './types'
+
+const STORAGE_DIR = 'local-data'
+const MESSAGES_FILE = 'messages.json'
+
+/**
+ * Local chat storage for desktop conversations.
+ * Single-session in v1, but keeps sessionId for forward compatibility.
+ */
+export class LocalStorage {
+  private storagePath: string
+  private messages: StoredLocalMessage[] = []
+  private initialized = false
+
+  constructor() {
+    this.storagePath = path.join(app.getPath('userData'), STORAGE_DIR)
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+    await fs.mkdir(this.storagePath, { recursive: true })
+    await this.loadData()
+    this.initialized = true
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.initialize()
+    }
+  }
+
+  private async loadData(): Promise<void> {
+    try {
+      const messagesPath = path.join(this.storagePath, MESSAGES_FILE)
+      const content = await fs.readFile(messagesPath, 'utf-8')
+      const data = JSON.parse(content)
+
+      if (Array.isArray(data)) {
+        this.messages = data as StoredLocalMessage[]
+        console.log(`[Local Storage] Loaded ${this.messages.length} messages`)
+      } else {
+        this.messages = []
+        await this.saveData()
+      }
+    } catch {
+      this.messages = []
+      console.log('[Local Storage] No existing messages found')
+    }
+  }
+
+  private async saveData(): Promise<void> {
+    const messagesPath = path.join(this.storagePath, MESSAGES_FILE)
+    await fs.writeFile(messagesPath, JSON.stringify(this.messages, null, 2), 'utf-8')
+  }
+
+  async storeMessage(message: StoredLocalMessage): Promise<void> {
+    await this.ensureInitialized()
+
+    const exists = this.messages.some(
+      (m) => m.messageId === message.messageId && m.sessionId === message.sessionId
+    )
+
+    if (!exists) {
+      this.messages.push(message)
+      await this.saveData()
+    }
+  }
+
+  async getMessages(limit?: number, sessionId = 'default'): Promise<StoredLocalMessage[]> {
+    await this.ensureInitialized()
+    const filtered = this.messages.filter((message) => message.sessionId === sessionId)
+    const sorted = [...filtered].sort((a, b) => a.date - b.date)
+    return limit ? sorted.slice(-limit) : sorted
+  }
+
+  async clearMessages(sessionId?: string): Promise<void> {
+    await this.ensureInitialized()
+    if (sessionId) {
+      this.messages = this.messages.filter((message) => message.sessionId !== sessionId)
+    } else {
+      this.messages = []
+    }
+    await this.saveData()
+  }
+}
+
+export const localStorage = new LocalStorage()

--- a/src/main/apps/local/types.ts
+++ b/src/main/apps/local/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Local chat platform types
+ */
+
+export interface StoredLocalMessage {
+  messageId: string
+  sessionId: string
+  text: string
+  date: number
+  isFromBot: boolean
+  replyToMessageId?: string
+  metadata?: Record<string, unknown>
+}

--- a/src/main/apps/slack/bot.service.ts
+++ b/src/main/apps/slack/bot.service.ts
@@ -331,7 +331,7 @@ export class SlackBotService {
       // In DMs: only use thread if user is already in one, otherwise reply directly
       // In channels: always reply in thread
       const replyThreadTs = isDM ? threadTs : (threadTs || messageTs)
-      await this.processWithAgentAndReply(channelId, cleanText, replyThreadTs, say, imageUrls, downloadedFiles)
+      await this.processWithAgentAndReply(channelId, userId, cleanText, replyThreadTs, say, imageUrls, downloadedFiles)
     }
   }
 
@@ -482,6 +482,7 @@ export class SlackBotService {
    */
   private async processWithAgentAndReply(
     channelId: string,
+    userId: string,
     userMessage: string,
     threadTs: string | undefined,
     say: (message: string | { text: string; thread_ts?: string }) => Promise<unknown>,
@@ -507,7 +508,10 @@ export class SlackBotService {
         return
       }
 
-      const response = await agentService.processMessage(fullMessage, 'slack', imageUrls)
+      const response = await agentService.processMessage(fullMessage, 'slack', imageUrls, undefined, {
+        source: 'message',
+        userId
+      })
 
       // Check if rejected due to processing lock
       if (!response.success && response.busyWith) {

--- a/src/main/apps/telegram/bot.service.ts
+++ b/src/main/apps/telegram/bot.service.ts
@@ -516,7 +516,7 @@ export class TelegramBotService {
 
     // Process with Agent and reply if there's content (text, images, or files)
     if ((textContent || imageUrls.length > 0 || filePaths.length > 0) && this.bot) {
-      await this.processWithAgentAndReply(msg.chat.id, textContent, imageUrls)
+      await this.processWithAgentAndReply(msg.chat.id, String(msg.from?.id || ''), textContent, imageUrls)
     }
   }
 
@@ -727,7 +727,12 @@ export class TelegramBotService {
   /**
    * Process message with Agent and send reply
    */
-  private async processWithAgentAndReply(chatId: number, userMessage: string, imageUrls: string[] = []): Promise<void> {
+  private async processWithAgentAndReply(
+    chatId: number,
+    userId: string,
+    userMessage: string,
+    imageUrls: string[] = []
+  ): Promise<void> {
     console.log('[Telegram] Sending to Agent:', userMessage, imageUrls.length > 0 ? `with ${imageUrls.length} images` : '')
 
     // Set current chat ID for tool calls
@@ -741,7 +746,10 @@ export class TelegramBotService {
       }
 
       // Get response from Agent with Telegram-specific tools and images
-      const response = await agentService.processMessage(userMessage, 'telegram', imageUrls)
+      const response = await agentService.processMessage(userMessage, 'telegram', imageUrls, undefined, {
+        source: 'message',
+        userId
+      })
       // #region agent log
       fetch('http://localhost:7892/ingest/443430ae-db47-457c-ba67-1dd0ac8fcd15',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'eafdcd'},body:JSON.stringify({sessionId:'eafdcd',location:'telegram.bot.service.ts:afterProcessMessage',message:'agent response received',data:{success:response.success,hasMessage:!!response.message,error:response.error?.substring?.(0,500),busyWith:response.busyWith},timestamp:Date.now(),hypothesisId:'D'})}).catch(()=>{});
       // #endregion

--- a/src/main/apps/types.ts
+++ b/src/main/apps/types.ts
@@ -3,7 +3,7 @@
  */
 
 // Supported app platforms
-export type AppPlatform = 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu'
+export type AppPlatform = 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu' | 'local'
 
 // Attachment structure for messages
 export interface MessageAttachment {

--- a/src/main/apps/whatsapp/bot.service.ts
+++ b/src/main/apps/whatsapp/bot.service.ts
@@ -150,14 +150,14 @@ export class WhatsAppBotService {
 
     // Process with Agent and reply
     if (text) {
-      await this.processWithAgentAndReply(chatId, text)
+      await this.processWithAgentAndReply(chatId, fromId, text)
     }
   }
 
   /**
    * Process message with Agent and send reply
    */
-  private async processWithAgentAndReply(chatId: string, userMessage: string): Promise<void> {
+  private async processWithAgentAndReply(chatId: string, userId: string, userMessage: string): Promise<void> {
     console.log('[WhatsApp] Sending to Agent:', userMessage.substring(0, 50) + '...')
 
     try {
@@ -167,7 +167,10 @@ export class WhatsAppBotService {
         return
       }
 
-      const response = await agentService.processMessage(userMessage, 'whatsapp')
+      const response = await agentService.processMessage(userMessage, 'whatsapp', [], undefined, {
+        source: 'message',
+        userId
+      })
 
       // Check if rejected due to processing lock
       if (!response.success && response.busyWith) {

--- a/src/main/config/settings.config.ts
+++ b/src/main/config/settings.config.ts
@@ -155,6 +155,9 @@ export interface AppSettings {
 
   // Power settings
   preventSleep: boolean
+
+  // File access boundary (empty string = os.homedir())
+  fileAccessBoundaryRoot: string
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -249,7 +252,10 @@ const DEFAULT_SETTINGS: AppSettings = {
   tavilyApiKey: '',
 
   // Power settings
-  preventSleep: true
+  preventSleep: true,
+
+  // File access boundary
+  fileAccessBoundaryRoot: ''
 }
 
 /**

--- a/src/main/config/settings.config.ts
+++ b/src/main/config/settings.config.ts
@@ -267,7 +267,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   // Bash tool security settings
   bashToolEnabled: true,
   bashToolRequireAuthorizedUser: true,
-  bashToolAllowedPlatforms: ['telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu'],
+  bashToolAllowedPlatforms: ['telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu', 'local'],
   bashToolAllowedSources: ['message'],
 }
 

--- a/src/main/config/settings.config.ts
+++ b/src/main/config/settings.config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises'
 import * as path from 'path'
 import { app } from 'electron'
+import type { MessagePlatform, ToolExecutionSource } from '../services/agent/types'
 
 const CONFIG_DIR = 'config'
 const SETTINGS_FILE = 'settings.json'
@@ -158,6 +159,12 @@ export interface AppSettings {
 
   // File access boundary (empty string = os.homedir())
   fileAccessBoundaryRoot: string
+
+  // Bash tool security settings
+  bashToolEnabled: boolean
+  bashToolRequireAuthorizedUser: boolean
+  bashToolAllowedPlatforms: MessagePlatform[]
+  bashToolAllowedSources: ToolExecutionSource[]
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -255,7 +262,13 @@ const DEFAULT_SETTINGS: AppSettings = {
   preventSleep: true,
 
   // File access boundary
-  fileAccessBoundaryRoot: ''
+  fileAccessBoundaryRoot: '',
+
+  // Bash tool security settings
+  bashToolEnabled: true,
+  bashToolRequireAuthorizedUser: true,
+  bashToolAllowedPlatforms: ['telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu'],
+  bashToolAllowedSources: ['message'],
 }
 
 /**

--- a/src/main/events/index.ts
+++ b/src/main/events/index.ts
@@ -52,6 +52,9 @@ export type AppEventType =
   | 'feishu:new-message'
   | 'feishu:status-changed'
   | 'feishu:messages-refresh'
+  | 'local:new-message'
+  | 'local:status-changed'
+  | 'local:messages-refresh'
   | 'llm:status-changed'
   | 'llm:activity-changed'
   | 'service:status-changed'
@@ -244,6 +247,31 @@ class AppEventEmitter extends EventEmitter {
   }
 
   /**
+   * Emit Local new message event
+   */
+  emitLocalNewMessage(message: AppMessage): void {
+    console.log('[Events] Emitting Local new message:', message.id)
+    this.emit('local:new-message', message)
+    this.sendToRenderer('local:new-message', message)
+  }
+
+  /**
+   * Emit Local status changed event
+   */
+  emitLocalStatusChanged(status: {
+    platform: string
+    isConnected: boolean
+    username?: string
+    botName?: string
+    avatarUrl?: string
+    error?: string
+  }): void {
+    console.log('[Events] Emitting Local status changed:', status)
+    this.emit('local:status-changed', status)
+    this.sendToRenderer('local:status-changed', status)
+  }
+
+  /**
    * Emit service status changed event
    */
   emitServiceStatusChanged(serviceId: string, status: ServiceStatusType): void {
@@ -265,7 +293,7 @@ class AppEventEmitter extends EventEmitter {
    * Emit messages refresh event for a platform
    * Used after deleting chat history to refresh UI
    */
-  emitMessagesRefresh(platform: 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu'): void {
+  emitMessagesRefresh(platform: 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'local'): void {
     const eventName = `${platform}:messages-refresh` as AppEventType
     console.log(`[Events] Emitting messages refresh for ${platform}`)
     this.emit(eventName, {})

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -13,6 +13,7 @@ import { setupLLMHandlers } from './llm.handlers'
 import { registerSkillsHandlers } from './skills.handlers'
 import { setupServiceHandlers } from './service.handlers'
 import { setupUpdaterHandlers } from './updater.handlers'
+import { guardFileBoundary } from '../utils/file-boundary'
 import type { IpcResponse, FileInfo } from '../types'
 
 /**
@@ -96,6 +97,7 @@ function setupFileHandlers(): void {
     'file:read',
     async (_event, path: string): Promise<IpcResponse<string>> => {
       try {
+        await guardFileBoundary(path, 'read')
         const content = await fileService.readFile(path)
         return { success: true, data: content }
       } catch (error) {
@@ -112,6 +114,7 @@ function setupFileHandlers(): void {
     'file:write',
     async (_event, path: string, content: string): Promise<IpcResponse> => {
       try {
+        await guardFileBoundary(path, 'write')
         await fileService.writeFile(path, content)
         return { success: true }
       } catch (error) {
@@ -128,6 +131,7 @@ function setupFileHandlers(): void {
     'file:list',
     async (_event, path: string): Promise<IpcResponse<FileInfo[]>> => {
       try {
+        await guardFileBoundary(path, 'read')
         const files = await fileService.listDirectory(path)
         return { success: true, data: files }
       } catch (error) {
@@ -144,6 +148,7 @@ function setupFileHandlers(): void {
     'file:delete',
     async (_event, path: string): Promise<IpcResponse> => {
       try {
+        await guardFileBoundary(path, 'delete')
         await fileService.deleteFile(path)
         return { success: true }
       } catch (error) {
@@ -160,6 +165,7 @@ function setupFileHandlers(): void {
     'file:exists',
     async (_event, path: string): Promise<IpcResponse<boolean>> => {
       try {
+        await guardFileBoundary(path, 'stat')
         const exists = await fileService.exists(path)
         return { success: true, data: exists }
       } catch (error) {
@@ -176,6 +182,7 @@ function setupFileHandlers(): void {
     'file:info',
     async (_event, path: string): Promise<IpcResponse<FileInfo>> => {
       try {
+        await guardFileBoundary(path, 'stat')
         const info = await fileService.getFileInfo(path)
         return { success: true, data: info }
       } catch (error) {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -7,6 +7,7 @@ import { setupWhatsAppHandlers } from './whatsapp.handlers'
 import { setupSlackHandlers } from './slack.handlers'
 import { setupLineHandlers } from './line.handlers'
 import { setupFeishuHandlers } from './feishu.handlers'
+import { setupLocalHandlers } from './local.handlers'
 import { setupSettingsHandlers } from './settings.handlers'
 import { setupSecurityHandlers } from './security.handlers'
 import { setupLLMHandlers } from './llm.handlers'
@@ -28,6 +29,7 @@ export async function setupIpcHandlers(): Promise<void> {
   setupSlackHandlers()
   setupLineHandlers()
   setupFeishuHandlers()
+  setupLocalHandlers()
   setupSettingsHandlers()
   setupSecurityHandlers()
   setupLLMHandlers()

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -45,7 +45,9 @@ function setupAgentHandlers(): void {
     'agent:send-message',
     async (_event, message: string): Promise<IpcResponse<string>> => {
       try {
-        const response = await agentService.processMessage(message)
+        const response = await agentService.processMessage(message, 'none', [], undefined, {
+          source: 'system'
+        })
 
         if (response.success) {
           return { success: true, data: response.message }

--- a/src/main/ipc/local.handlers.ts
+++ b/src/main/ipc/local.handlers.ts
@@ -1,0 +1,56 @@
+import { ipcMain } from 'electron'
+import { localChatService } from '../apps/local'
+import type { IpcResponse, AppMessage, BotStatus } from '../types'
+
+export function setupLocalHandlers(): void {
+  ipcMain.handle('local:send-message', async (_event, message: string): Promise<IpcResponse<AppMessage>> => {
+    try {
+      const result = await localChatService.sendMessage(message)
+      if (!result.success) {
+        return { success: false, error: result.error }
+      }
+      return { success: true, data: result.data }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  })
+
+  ipcMain.handle('local:get-messages', async (_event, limit?: number): Promise<IpcResponse<AppMessage[]>> => {
+    try {
+      const messages = await localChatService.getMessages(limit)
+      return { success: true, data: messages }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  })
+
+  ipcMain.handle('local:clear-messages', async (): Promise<IpcResponse> => {
+    try {
+      await localChatService.clearMessages()
+      return { success: true }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  })
+
+  ipcMain.handle('local:status', async (): Promise<IpcResponse<BotStatus>> => {
+    try {
+      await localChatService.initialize()
+      return { success: true, data: localChatService.getStatus() }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error)
+      }
+    }
+  })
+}

--- a/src/main/services/__tests__/bash-tool-access.test.ts
+++ b/src/main/services/__tests__/bash-tool-access.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../security.service', () => ({
+  securityService: {
+    isAuthorizedByStringId: vi.fn(),
+  },
+}))
+
+vi.mock('../../config/settings.config', () => ({
+  loadSettings: vi.fn(),
+}))
+
+import { getBashToolAccessDecision, evaluateBashToolAccess, type BashToolSettings } from '../bash-tool-access'
+import { securityService } from '../security.service'
+import type { ToolExecutionContext } from '../agent/types'
+
+const mockedSecurityService = vi.mocked(securityService)
+
+function createSettings(overrides: Partial<BashToolSettings> = {}): BashToolSettings {
+  return {
+    bashToolEnabled: true,
+    bashToolRequireAuthorizedUser: true,
+    bashToolAllowedPlatforms: ['telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu'],
+    bashToolAllowedSources: ['message'],
+    ...overrides,
+  }
+}
+
+function createContext(overrides: Partial<ToolExecutionContext> = {}): ToolExecutionContext {
+  return {
+    platform: 'telegram',
+    source: 'message',
+    userId: '123456',
+    ...overrides,
+  }
+}
+
+describe('bash tool access control', () => {
+  beforeEach(() => {
+    mockedSecurityService.isAuthorizedByStringId.mockReset()
+  })
+
+  it('rejects any bash call when globally disabled', () => {
+    const result = evaluateBashToolAccess(
+      createSettings({ bashToolEnabled: false }),
+      createContext(),
+      true
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'Bash tool is disabled',
+    })
+  })
+
+  it('rejects unauthorized users when bash requires an authorized user', async () => {
+    mockedSecurityService.isAuthorizedByStringId.mockResolvedValue(false)
+
+    const result = await getBashToolAccessDecision(createContext(), createSettings())
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'Bash tool is not allowed for this user',
+    })
+  })
+
+  it('allows authorized users on permitted platforms', async () => {
+    mockedSecurityService.isAuthorizedByStringId.mockResolvedValue(true)
+
+    const result = await getBashToolAccessDecision(
+      createContext({ platform: 'discord', userId: '987654321' }),
+      createSettings()
+    )
+
+    expect(result).toEqual({ allowed: true })
+  })
+
+  it('rejects calls from platforms outside the allow list', () => {
+    const result = evaluateBashToolAccess(
+      createSettings({ bashToolAllowedPlatforms: ['discord'] }),
+      createContext(),
+      true
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'Bash tool is not allowed in this execution context',
+    })
+  })
+
+  it('rejects platformless and proactive contexts by default', () => {
+    const result = evaluateBashToolAccess(
+      createSettings(),
+      createContext({ platform: 'none', source: 'proactive', userId: undefined }),
+      null
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'Bash tool is not allowed in this execution context',
+    })
+  })
+})

--- a/src/main/services/agent.service.ts
+++ b/src/main/services/agent.service.ts
@@ -11,6 +11,7 @@ import { telegramStorage } from '../apps/telegram/storage'
 import { discordStorage } from '../apps/discord/storage'
 import { slackStorage } from '../apps/slack/storage'
 import { feishuStorage } from '../apps/feishu/storage'
+import { localStorage } from '../apps/local/storage'
 import type { ConversationMessage, AgentResponse } from '../types'
 import * as fs from 'fs/promises'
 
@@ -849,21 +850,16 @@ export class AgentService {
       const storageLoadLimit = this.getStorageLoadLimit(settings)
       let messages: Array<{ text?: string; isFromBot: boolean }> = []
 
-      if (platform === 'telegram') {
-        const storedMessages = await telegramStorage.getMessages(storageLoadLimit)
-        messages = storedMessages.map(m => ({
-          text: m.text,
-          isFromBot: m.isFromBot
-        }))
-      } else if (platform === 'discord') {
-        const storedMessages = await discordStorage.getMessages(storageLoadLimit)
-        messages = storedMessages.map(m => ({
-          text: m.text,
-          isFromBot: m.isFromBot
-        }))
-      } else if (platform === 'slack') {
-        const storedMessages = await slackStorage.getMessages(storageLoadLimit)
-        messages = storedMessages.map(m => ({
+      if (platform === 'telegram' || platform === 'discord' || platform === 'slack' || platform === 'local') {
+        const storageReaders = {
+          telegram: () => telegramStorage.getMessages(storageLoadLimit),
+          discord: () => discordStorage.getMessages(storageLoadLimit),
+          slack: () => slackStorage.getMessages(storageLoadLimit),
+          local: () => localStorage.getMessages(storageLoadLimit, chatId || 'default')
+        } as const
+
+        const storedMessages = await storageReaders[platform]()
+        messages = storedMessages.map((m) => ({
           text: m.text,
           isFromBot: m.isFromBot
         }))

--- a/src/main/services/agent.service.ts
+++ b/src/main/services/agent.service.ts
@@ -93,6 +93,7 @@ import {
   createLLMTopicClassifier,
   type TopicScorer
 } from './agent/context/layered/temporary-topic'
+import { getBashToolAccessDecision } from './bash-tool-access'
 import { getToolsForPlatform } from './agent/tools'
 import { executeTool } from './agent/tool-executor'
 import { getSystemPromptForPlatform } from './agent/prompt-builder'
@@ -106,6 +107,8 @@ export type {
   EvaluationData,
   LLMStatus,
   LLMStatusInfo,
+  ToolExecutionContext,
+  ToolExecutionSource,
   AgentActivityType,
   AgentActivityItem
 } from './agent/types'
@@ -117,6 +120,7 @@ import type {
   EvaluationContext,
   EvaluationData,
   EvaluationDecision,
+  ToolExecutionContext,
   AgentActivityItem
 } from './agent/types'
 
@@ -136,6 +140,10 @@ export class AgentService {
   private abortController: AbortController | null = null
   private isAborted = false
   private currentPlatform: MessagePlatform = 'none'
+  private currentToolExecutionContext: ToolExecutionContext = {
+    platform: 'none',
+    source: 'system'
+  }
   private contextLoadedForPlatform: MessagePlatform | null = null // Track which platform's context is loaded
   private contextLoadedForChatId: string | null = null // Track which chatId's context is loaded (for per-chat isolation)
   private recentReplyPlatform: MessagePlatform = 'none' // Track which platform the user most recently sent a message from (persisted to disk)
@@ -1018,7 +1026,8 @@ export class AgentService {
     userMessage: string,
     platform: MessagePlatform = 'none',
     imageUrls: string[] = [],
-    chatId?: string
+    chatId?: string,
+    toolExecutionContext?: Partial<ToolExecutionContext>
   ): Promise<AgentResponse> {
     // Check if agent is currently processing (same or different platform)
     const lockCheck = this.canProcess(platform)
@@ -1046,6 +1055,12 @@ export class AgentService {
     this.isAborted = false
     this.abortController = new AbortController()
     this.currentPlatform = platform
+    this.currentToolExecutionContext = {
+      platform,
+      source: toolExecutionContext?.source ?? (platform === 'none' ? 'system' : 'message'),
+      userId: toolExecutionContext?.userId,
+      isAuthorizedUser: toolExecutionContext?.isAuthorizedUser
+    }
     
     // Clear activity log for new processing session
     this.clearActivityLog()
@@ -1187,6 +1202,10 @@ export class AgentService {
       }
     } finally {
       this.abortController = null
+      this.currentToolExecutionContext = {
+        platform: 'none',
+        source: 'system'
+      }
       // Release the processing lock
       console.log(`[Agent] Lock released by ${this.processingLock}`)
       this.processingLock = null
@@ -1206,8 +1225,12 @@ export class AgentService {
       visualModeEnabled: settings.experimentalVisualMode,
       computerUseEnabled: settings.experimentalComputerUse
     })
+    const bashAccess = await getBashToolAccessDecision(this.currentToolExecutionContext, settings)
+    const effectiveTools = bashAccess.allowed
+      ? tools
+      : tools.filter((tool) => tool.name !== 'bash')
     // #region agent log
-    fetch('http://localhost:7892/ingest/443430ae-db47-457c-ba67-1dd0ac8fcd15',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'eafdcd'},body:JSON.stringify({sessionId:'eafdcd',location:'agent.service.ts:runAgentLoop',message:'tools loaded',data:{totalTools:tools.length,mcpTools:tools.filter(t=>t.name.startsWith('mcp_')).map(t=>({name:t.name,schemaKeys:Object.keys(t.input_schema||{})})),provider,model},timestamp:Date.now(),hypothesisId:'A,B,C'})}).catch(()=>{});
+    fetch('http://localhost:7892/ingest/443430ae-db47-457c-ba67-1dd0ac8fcd15',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'eafdcd'},body:JSON.stringify({sessionId:'eafdcd',location:'agent.service.ts:runAgentLoop',message:'tools loaded',data:{totalTools:effectiveTools.length,mcpTools:effectiveTools.filter(t=>t.name.startsWith('mcp_')).map(t=>({name:t.name,schemaKeys:Object.keys(t.input_schema||{})})),provider,model},timestamp:Date.now(),hypothesisId:'A,B,C'})}).catch(()=>{});
     // #endregion
 
     // Enforce message count limit once before the loop starts
@@ -1221,7 +1244,7 @@ export class AgentService {
     console.log(`[Agent] Using tools for platform: ${this.currentPlatform}`)
     console.log(`[Agent] Visual mode: ${settings.experimentalVisualMode ? 'enabled' : 'disabled'}`)
     console.log(`[Agent] Computer use: ${settings.experimentalComputerUse ? 'enabled' : 'disabled'}`)
-    console.log(`[Agent] Available tools: ${tools.map(t => t.name).join(', ')}`)
+    console.log(`[Agent] Available tools: ${effectiveTools.map(t => t.name).join(', ')}`)
 
     let iterations = 0
     const maxIterations = 50 // Prevent infinite loops
@@ -1246,7 +1269,7 @@ export class AgentService {
       // Estimate tokens before API call for debugging
       const estimatedMsgTokens = this.conversationHistory.reduce((sum, msg) => sum + estimateTokens(msg), 0)
       const estimatedSystemTokens = Math.ceil(systemPrompt.length / 3)
-      const estimatedToolsTokens = Math.ceil(JSON.stringify(tools).length / 3)
+      const estimatedToolsTokens = Math.ceil(JSON.stringify(effectiveTools).length / 3)
       const estimatedTotalTokens = estimatedMsgTokens + estimatedSystemTokens + estimatedToolsTokens
       console.log(`[Agent] Estimated tokens - messages: ${estimatedMsgTokens}, system: ${estimatedSystemTokens}, tools: ${estimatedToolsTokens}, total: ${estimatedTotalTokens}`)
       
@@ -1278,7 +1301,7 @@ export class AgentService {
             model,
             max_tokens: maxTokens,
             system: systemPrompt,
-            tools,
+            tools: effectiveTools,
             messages: this.conversationHistory,
             // Enable context editing to automatically clear old tool results when approaching token limit
             betas: ['context-management-2025-06-27'],
@@ -1315,7 +1338,7 @@ export class AgentService {
             maxTokens,
             0.7,
             systemPrompt,
-            tools,
+            effectiveTools,
             this.conversationHistory
           );
         } else if (provider === 'gemini') {
@@ -1330,7 +1353,7 @@ export class AgentService {
             maxTokens,
             0.7,
             systemPrompt,
-            tools,
+            effectiveTools,
             this.conversationHistory,
             geminiToolIdMap
           );
@@ -1348,7 +1371,7 @@ export class AgentService {
             model,
             max_tokens: maxTokens,
             system: systemPrompt,
-            tools,
+            tools: effectiveTools,
             messages: this.conversationHistory
           })
         }
@@ -1579,7 +1602,7 @@ export class AgentService {
     name: string,
     input: unknown
   ): Promise<{ success: boolean; data?: unknown; error?: string }> {
-    return await executeTool(name, input, this.currentPlatform)
+    return await executeTool(name, input, this.currentPlatform, this.currentToolExecutionContext)
   }
 
   /**

--- a/src/main/services/agent/__tests__/tool-executor.bash.test.ts
+++ b/src/main/services/agent/__tests__/tool-executor.bash.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../tools/computer.executor', () => ({
+  executeComputerTool: vi.fn(),
+  executeBashTool: vi.fn(),
+  executeTextEditorTool: vi.fn(),
+  executeDownloadFileTool: vi.fn(),
+  executeWebSearchTool: vi.fn(),
+}))
+
+vi.mock('../../../tools/macos/definitions', () => ({
+  isMacOS: () => false,
+}))
+
+vi.mock('../../../tools/macos/executor', () => ({
+  executeMacOSLaunchAppTool: vi.fn(),
+  executeMacOSMailTool: vi.fn(),
+  executeMacOSCalendarTool: vi.fn(),
+  executeMacOSContactsTool: vi.fn(),
+}))
+
+vi.mock('../../../tools/macos/visual.executor', () => ({
+  executeMacOSShowTool: vi.fn(),
+  executeMacOSCloseTool: vi.fn(),
+}))
+
+vi.mock('../../../tools/telegram.executor', () => ({ executeTelegramTool: vi.fn() }))
+vi.mock('../../../tools/discord.executor', () => ({ executeDiscordTool: vi.fn() }))
+vi.mock('../../../tools/whatsapp.executor', () => ({ executeWhatsAppTool: vi.fn() }))
+vi.mock('../../../tools/slack.executor', () => ({ executeSlackTool: vi.fn() }))
+vi.mock('../../../tools/line.executor', () => ({ executeLineTool: vi.fn() }))
+vi.mock('../../../tools/feishu.executor', () => ({ executeFeishuTool: vi.fn() }))
+vi.mock('../../../tools/service.executor', () => ({ executeServiceTool: vi.fn() }))
+vi.mock('../../../tools/memu.executor', () => ({ executeMemuTool: vi.fn() }))
+
+vi.mock('../../bash-tool-access', () => ({
+  getBashToolAccessDecision: vi.fn(),
+}))
+
+vi.mock('../../mcp.service', () => ({
+  mcpService: {
+    isMcpTool: vi.fn(() => false),
+    executeTool: vi.fn(),
+  },
+}))
+
+import { executeBashTool, executeWebSearchTool } from '../../../tools/computer.executor'
+import { getBashToolAccessDecision } from '../../bash-tool-access'
+import { executeTool } from '../tool-executor'
+import type { ToolExecutionContext } from '../types'
+
+const mockedExecuteBashTool = vi.mocked(executeBashTool)
+const mockedExecuteWebSearchTool = vi.mocked(executeWebSearchTool)
+const mockedGetBashToolAccessDecision = vi.mocked(getBashToolAccessDecision)
+
+const messageContext: ToolExecutionContext = {
+  platform: 'telegram',
+  source: 'message',
+  userId: '123456',
+}
+
+describe('agent tool executor bash access control', () => {
+  beforeEach(() => {
+    mockedExecuteBashTool.mockReset()
+    mockedExecuteWebSearchTool.mockReset()
+    mockedGetBashToolAccessDecision.mockReset()
+  })
+
+  it('blocks bash execution when access is denied', async () => {
+    mockedGetBashToolAccessDecision.mockResolvedValue({
+      allowed: false,
+      reason: 'Bash tool is disabled',
+    })
+
+    const result = await executeTool('bash', { command: 'pwd' }, 'telegram', messageContext)
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Bash tool is disabled',
+    })
+    expect(mockedExecuteBashTool).not.toHaveBeenCalled()
+  })
+
+  it('allows bash execution when access is granted', async () => {
+    mockedGetBashToolAccessDecision.mockResolvedValue({ allowed: true })
+    mockedExecuteBashTool.mockResolvedValue({ success: true, data: 'ok' })
+
+    const result = await executeTool('bash', { command: 'pwd' }, 'telegram', messageContext)
+
+    expect(mockedExecuteBashTool).toHaveBeenCalledWith({ command: 'pwd' })
+    expect(result).toEqual({ success: true, data: 'ok' })
+  })
+
+  it('does not affect non-bash tools', async () => {
+    mockedExecuteWebSearchTool.mockResolvedValue({
+      success: true,
+      data: { query: 'memu', resultCount: 1 },
+    })
+
+    const result = await executeTool('web_search', { query: 'memu' }, 'telegram', messageContext)
+
+    expect(mockedGetBashToolAccessDecision).not.toHaveBeenCalled()
+    expect(mockedExecuteWebSearchTool).toHaveBeenCalledWith({ query: 'memu' })
+    expect(result).toEqual({
+      success: true,
+      data: { query: 'memu', resultCount: 1 },
+    })
+  })
+})

--- a/src/main/services/agent/tool-executor.ts
+++ b/src/main/services/agent/tool-executor.ts
@@ -10,8 +10,9 @@ import { executeLineTool } from '../../tools/line.executor'
 import { executeFeishuTool } from '../../tools/feishu.executor'
 import { executeServiceTool } from '../../tools/service.executor'
 import { executeMemuTool } from '../../tools/memu.executor'
+import { getBashToolAccessDecision } from '../bash-tool-access'
 import { mcpService } from '../mcp.service'
-import type { MessagePlatform, ToolResult } from './types'
+import type { MessagePlatform, ToolExecutionContext, ToolResult } from './types'
 
 /**
  * Execute a single tool by name
@@ -22,15 +23,28 @@ import type { MessagePlatform, ToolResult } from './types'
 export async function executeTool(
   name: string,
   input: unknown,
-  currentPlatform: MessagePlatform
+  currentPlatform: MessagePlatform,
+  executionContext?: ToolExecutionContext
 ): Promise<ToolResult> {
+  const toolContext: ToolExecutionContext = executionContext
+    ? { ...executionContext, platform: currentPlatform }
+    : {
+        platform: currentPlatform,
+        source: currentPlatform === 'none' ? 'system' : 'message',
+      }
+
   // Computer use tools
   switch (name) {
     case 'computer':
       return await executeComputerTool(input as Parameters<typeof executeComputerTool>[0])
 
-    case 'bash':
+    case 'bash': {
+      const access = await getBashToolAccessDecision(toolContext)
+      if (!access.allowed) {
+        return { success: false, error: access.reason }
+      }
       return await executeBashTool(input as Parameters<typeof executeBashTool>[0])
+    }
 
     case 'str_replace_editor':
       return await executeTextEditorTool(input as Parameters<typeof executeTextEditorTool>[0])

--- a/src/main/services/agent/tools.ts
+++ b/src/main/services/agent/tools.ts
@@ -61,6 +61,7 @@ export function getToolsForPlatform(platform: MessagePlatform, options: Experime
       return [...baseTools, ...platformTools, ...visualTools, ...lineTools, ...svcTools, ...memuTools, ...mcpTools]
     case 'feishu':
       return [...baseTools, ...platformTools, ...visualTools, ...feishuTools, ...svcTools, ...memuTools, ...mcpTools]
+    case 'local':
     case 'none':
     default:
       return [...baseTools, ...platformTools, ...visualTools, ...svcTools, ...memuTools, ...mcpTools]

--- a/src/main/services/agent/types.ts
+++ b/src/main/services/agent/types.ts
@@ -3,7 +3,7 @@ import type Anthropic from '@anthropic-ai/sdk'
 /**
  * Supported platforms for messaging tools
  */
-export type MessagePlatform = 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'
+export type MessagePlatform = 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'local' | 'none'
 
 export type ToolExecutionSource = 'message' | 'proactive' | 'system' | 'service'
 

--- a/src/main/services/agent/types.ts
+++ b/src/main/services/agent/types.ts
@@ -5,6 +5,15 @@ import type Anthropic from '@anthropic-ai/sdk'
  */
 export type MessagePlatform = 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'
 
+export type ToolExecutionSource = 'message' | 'proactive' | 'system' | 'service'
+
+export interface ToolExecutionContext {
+  platform: MessagePlatform
+  source: ToolExecutionSource
+  userId?: string
+  isAuthorizedUser?: boolean
+}
+
 /**
  * Unmemorized message with metadata
  */

--- a/src/main/services/bash-tool-access.ts
+++ b/src/main/services/bash-tool-access.ts
@@ -1,0 +1,69 @@
+import { loadSettings, type AppSettings } from '../config/settings.config'
+import { securityService, type Platform } from './security.service'
+import type { ToolExecutionContext } from './agent/types'
+
+export type BashToolSettings = Pick<
+  AppSettings,
+  | 'bashToolEnabled'
+  | 'bashToolRequireAuthorizedUser'
+  | 'bashToolAllowedPlatforms'
+  | 'bashToolAllowedSources'
+>
+
+export interface BashToolAccessDecision {
+  allowed: boolean
+  reason?: string
+}
+
+const BASH_DISABLED_MESSAGE = 'Bash tool is disabled'
+const BASH_USER_DENIED_MESSAGE = 'Bash tool is not allowed for this user'
+const BASH_CONTEXT_DENIED_MESSAGE = 'Bash tool is not allowed in this execution context'
+
+function isBoundUserPlatform(platform: ToolExecutionContext['platform']): platform is Platform {
+  return platform !== 'none'
+}
+
+async function resolveAuthorizedUser(context: ToolExecutionContext): Promise<boolean | null> {
+  if (context.userId && isBoundUserPlatform(context.platform)) {
+    return await securityService.isAuthorizedByStringId(context.userId, context.platform)
+  }
+
+  if (context.isAuthorizedUser !== undefined) {
+    return context.isAuthorizedUser
+  }
+
+  return null
+}
+
+export function evaluateBashToolAccess(
+  settings: BashToolSettings,
+  context: ToolExecutionContext,
+  isAuthorizedUser: boolean | null
+): BashToolAccessDecision {
+  if (!settings.bashToolEnabled) {
+    return { allowed: false, reason: BASH_DISABLED_MESSAGE }
+  }
+
+  if (!settings.bashToolAllowedSources.includes(context.source)) {
+    return { allowed: false, reason: BASH_CONTEXT_DENIED_MESSAGE }
+  }
+
+  if (!settings.bashToolAllowedPlatforms.includes(context.platform)) {
+    return { allowed: false, reason: BASH_CONTEXT_DENIED_MESSAGE }
+  }
+
+  if (settings.bashToolRequireAuthorizedUser && isAuthorizedUser !== true) {
+    return { allowed: false, reason: BASH_USER_DENIED_MESSAGE }
+  }
+
+  return { allowed: true }
+}
+
+export async function getBashToolAccessDecision(
+  context: ToolExecutionContext,
+  settingsOverride?: BashToolSettings
+): Promise<BashToolAccessDecision> {
+  const settings = settingsOverride ?? await loadSettings()
+  const isAuthorizedUser = await resolveAuthorizedUser(context)
+  return evaluateBashToolAccess(settings, context, isAuthorizedUser)
+}

--- a/src/main/services/infra.service.ts
+++ b/src/main/services/infra.service.ts
@@ -6,7 +6,7 @@ import type Anthropic from '@anthropic-ai/sdk'
 /**
  * Supported platforms for messaging
  */
-export type MessagePlatform = 'telegram' | 'discord' | 'slack' | 'whatsapp' | 'line' | 'feishu' | 'none'
+export type MessagePlatform = 'telegram' | 'discord' | 'slack' | 'whatsapp' | 'line' | 'feishu' | 'local' | 'none'
 
 /**
  * Event types for the infra bus

--- a/src/main/services/proactive.service.ts
+++ b/src/main/services/proactive.service.ts
@@ -18,6 +18,7 @@ import { discordBotService } from '../apps/discord/bot.service'
 import { slackBotService } from '../apps/slack/bot.service'
 import { whatsappBotService } from '../apps/whatsapp/bot.service'
 import { lineBotService } from '../apps/line/bot.service'
+import { localChatService } from '../apps/local'
 import type { AgentResponse } from '../types'
 
 /**
@@ -902,6 +903,12 @@ class ProactiveService {
           }
           console.error('[Proactive] Failed to send to Line:', result.error)
           return null
+        }
+
+        case 'local': {
+          await localChatService.sendBotMessage(message)
+          console.log('[Proactive] Message sent to Local chat successfully')
+          return platform
         }
 
         default:

--- a/src/main/services/proactive.service.ts
+++ b/src/main/services/proactive.service.ts
@@ -4,6 +4,7 @@ import { loadSettings } from '../config/settings.config'
 import { runOpenAIAdapter } from './agent/openai-adapter'
 import { runGeminiAdapter, createToolUseIdMap } from './agent/gemini-adapter'
 import { detectCustomProtocol } from './agent/utils'
+import { getBashToolAccessDecision } from './bash-tool-access'
 import { agentService, type MessagePlatform } from './agent.service'
 import { proactiveStorage } from './proactive.storage'
 import { infraService, type IncomingMessageEvent, type OutgoingMessageEvent } from './infra.service'
@@ -177,12 +178,20 @@ class ProactiveService {
    * Includes: base tools, platform tools (macOS), MCP tools, and memu tools
    * Note: Messaging platform tools (telegram, discord, etc.) are NOT enabled
    */
-  private getTools(): Anthropic.Tool[] {
+  private async getTools(): Promise<Anthropic.Tool[]> {
     const baseTools = [...computerUseTools]
     const platformTools = getMacOSTools() // Returns empty array on non-macOS
     const mcpTools = mcpService.getTools()
-    
-    return [...baseTools, ...platformTools, ...mcpTools, ...memuTools]
+    const settings = await loadSettings()
+    const bashAccess = await getBashToolAccessDecision(
+      { platform: 'none', source: 'proactive' },
+      settings
+    )
+    const filteredBaseTools = bashAccess.allowed
+      ? baseTools
+      : baseTools.filter((tool) => tool.name !== 'bash')
+
+    return [...filteredBaseTools, ...platformTools, ...mcpTools, ...memuTools]
   }
 
   /**
@@ -583,7 +592,7 @@ class ProactiveService {
   private async runAgentLoop(): Promise<AgentResponse> {
     const { client, model, maxTokens, provider, geminiApiKey } = await this.createClient()
     const geminiToolIdMap = provider === 'gemini' ? createToolUseIdMap() : undefined
-    const tools = this.getTools()
+    const tools = await this.getTools()
 
     console.log('[Proactive] Starting agent loop')
     console.log(`[Proactive] Available tools: ${tools.map(t => t.name).join(', ')}`)
@@ -745,8 +754,13 @@ class ProactiveService {
       case 'computer':
         return await executeComputerTool(input as Parameters<typeof executeComputerTool>[0])
 
-      case 'bash':
+      case 'bash': {
+        const access = await getBashToolAccessDecision({ platform: 'none', source: 'proactive' })
+        if (!access.allowed) {
+          return { success: false, error: access.reason }
+        }
         return await executeBashTool(input as Parameters<typeof executeBashTool>[0])
+      }
 
       case 'str_replace_editor':
         return await executeTextEditorTool(input as Parameters<typeof executeTextEditorTool>[0])

--- a/src/main/tools/computer.definitions.ts
+++ b/src/main/tools/computer.definitions.ts
@@ -65,6 +65,7 @@ export const bashTool: Anthropic.Tool = {
   description: `Execute a bash command on the system. Use this for running shell commands, installing packages, managing files via command line, etc.
   
 Important notes:
+- This is a high-risk tool and may be restricted by security settings
 - Commands run in the user's default shell
 - Working directory persists between calls
 - Long-running commands will timeout after 30 seconds

--- a/src/main/tools/computer/common.ts
+++ b/src/main/tools/computer/common.ts
@@ -13,6 +13,7 @@ import * as https from 'https'
 import * as http from 'http'
 import { app, screen, nativeImage } from 'electron'
 import screenshot from 'screenshot-desktop'
+import { guardFileBoundary } from '../../utils/file-boundary'
 const execAsync = promisify(exec)
 
 /**
@@ -359,6 +360,17 @@ export async function executeTextEditorTool(input: {
 }): Promise<{ success: boolean; data?: unknown; error?: string }> {
   try {
     const filePath = input.path
+
+    const intentMap: Record<string, 'read' | 'write' | 'create'> = {
+      view: 'read',
+      create: 'create',
+      str_replace: 'write',
+      insert: 'write',
+    }
+    const intent = intentMap[input.command]
+    if (intent) {
+      await guardFileBoundary(filePath, intent)
+    }
 
     switch (input.command) {
       case 'view': {

--- a/src/main/tools/executor.ts
+++ b/src/main/tools/executor.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import * as readline from 'readline'
 import { app } from 'electron'
 import { truncateOutput } from './computer.executor'
+import { guardFileBoundary } from '../utils/file-boundary'
 import type {
   ReadFileInput,
   WriteFileInput,
@@ -72,6 +73,8 @@ async function executeGrepFile(input: GrepFileInput): Promise<ToolResult> {
     ? input.path 
     : path.join(app.getPath('home'), input.path)
   
+  await guardFileBoundary(targetPath, 'read')
+
   try {
     const regex = new RegExp(input.pattern, 'i')
     const stats = await fs.promises.stat(targetPath)
@@ -175,6 +178,7 @@ async function searchDirectory(
  * Output includes line numbers for easy reference
  */
 async function executeReadFile(input: ReadFileInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'read')
   const content = await fileService.readFile(input.path)
   const lines = content.split('\n')
   
@@ -208,11 +212,13 @@ async function executeReadFile(input: ReadFileInput): Promise<ToolResult> {
 }
 
 async function executeWriteFile(input: WriteFileInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'write')
   await fileService.writeFile(input.path, input.content)
   return { success: true, data: `File written successfully: ${input.path}` }
 }
 
 async function executeListDirectory(input: ListDirectoryInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'read')
   const files = await fileService.listDirectory(input.path)
   // Truncate if file list is too large
   const output = Array.isArray(files) ? files.join('\n') : String(files)
@@ -220,16 +226,19 @@ async function executeListDirectory(input: ListDirectoryInput): Promise<ToolResu
 }
 
 async function executeDeleteFile(input: DeleteFileInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'delete')
   await fileService.deleteFile(input.path)
   return { success: true, data: `Deleted successfully: ${input.path}` }
 }
 
 async function executeCreateDirectory(input: CreateDirectoryInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'create')
   await fileService.createDirectory(input.path)
   return { success: true, data: `Directory created: ${input.path}` }
 }
 
 async function executeGetFileInfo(input: FileInfoInput): Promise<ToolResult> {
+  await guardFileBoundary(input.path, 'stat')
   const info = await fileService.getFileInfo(input.path)
   return { success: true, data: info }
 }

--- a/src/main/utils/__tests__/path-boundary-guard.test.ts
+++ b/src/main/utils/__tests__/path-boundary-guard.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import * as crypto from 'node:crypto'
+
+import { isPathInside } from '../path-guards'
+import { resolveBoundaryPath, resolveBoundaryPathSync } from '../boundary-path'
+import { assertNoHardlinkedFinalPath, assertNoHardlinkedFinalPathSync } from '../hardlink-guards'
+import { assertNoPathAliasEscape, assertNoPathAliasEscapeSync } from '../path-alias-guards'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpRoot: string
+let sandbox: string
+let outside: string
+
+beforeEach(async () => {
+  tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'pbg-test-'))
+  sandbox = path.join(tmpRoot, 'sandbox')
+  outside = path.join(tmpRoot, 'outside')
+  await fsp.mkdir(sandbox, { recursive: true })
+  await fsp.mkdir(outside, { recursive: true })
+})
+
+afterEach(async () => {
+  await fsp.rm(tmpRoot, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// 1. Lexical path tests (isPathInside – no I/O)
+// ---------------------------------------------------------------------------
+
+describe('isPathInside (lexical)', () => {
+  it('allows a child path', () => {
+    expect(isPathInside('/root', '/root/child')).toBe(true)
+  })
+
+  it('allows root equal to target', () => {
+    expect(isPathInside('/root', '/root')).toBe(true)
+  })
+
+  it('rejects ../ traversal', () => {
+    expect(isPathInside('/root', '/root/../etc/passwd')).toBe(false)
+  })
+
+  it('rejects absolute path outside root', () => {
+    expect(isPathInside('/root', '/other/file')).toBe(false)
+  })
+
+  it('allows deeply nested path', () => {
+    expect(isPathInside('/a', '/a/b/c/d/e')).toBe(true)
+  })
+
+  it('rejects sibling directory', () => {
+    expect(isPathInside('/a/b', '/a/c')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. Symlink tests (skip on Windows)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(process.platform === 'win32')('symlink boundary checks', () => {
+  it('allows symlink pointing inside the sandbox', async () => {
+    const realDir = path.join(sandbox, 'realdir')
+    await fsp.mkdir(realDir)
+    await fsp.writeFile(path.join(realDir, 'file.txt'), 'ok')
+
+    const linkPath = path.join(sandbox, 'link-to-realdir')
+    await fsp.symlink(realDir, linkPath)
+
+    const target = path.join(linkPath, 'file.txt')
+    const result = await resolveBoundaryPath({
+      absolutePath: target,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(true)
+    expect(result.kind).toBe('file')
+  })
+
+  it('rejects symlink pointing outside the sandbox', async () => {
+    const outsideFile = path.join(outside, 'secret.txt')
+    await fsp.writeFile(outsideFile, 'secret')
+
+    const linkPath = path.join(sandbox, 'escape-link')
+    await fsp.symlink(outside, linkPath)
+
+    const target = path.join(linkPath, 'secret.txt')
+    await expect(
+      resolveBoundaryPath({
+        absolutePath: target,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).rejects.toThrow(/Symlink.*escapes sandbox root/)
+  })
+
+  it('rejects accessing non-existent file through escaping symlink', async () => {
+    const linkPath = path.join(sandbox, 'escape-link')
+    await fsp.symlink(outside, linkPath)
+
+    const target = path.join(linkPath, 'does-not-exist.txt')
+    await expect(
+      resolveBoundaryPath({
+        absolutePath: target,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).rejects.toThrow(/Symlink.*escapes sandbox root/)
+  })
+
+  it('allows final symlink for unlink when policy permits', async () => {
+    const outsideFile = path.join(outside, 'target.txt')
+    await fsp.writeFile(outsideFile, 'data')
+
+    const linkPath = path.join(sandbox, 'external-link')
+    await fsp.symlink(outsideFile, linkPath)
+
+    const result = await resolveBoundaryPath({
+      absolutePath: linkPath,
+      rootPath: sandbox,
+      intent: 'delete',
+      boundaryLabel: 'sandbox root',
+      policy: { allowFinalSymlinkForUnlink: true },
+    })
+
+    expect(result.kind).toBe('symlink')
+    expect(result.exists).toBe(true)
+  })
+
+  it('allows root accessed via symlink alias when canonical is inside boundary', async () => {
+    const realSandbox = path.join(tmpRoot, 'real-sandbox')
+    await fsp.mkdir(realSandbox, { recursive: true })
+    await fsp.writeFile(path.join(realSandbox, 'hello.txt'), 'hi')
+
+    const aliasRoot = path.join(tmpRoot, 'alias-sandbox')
+    await fsp.symlink(realSandbox, aliasRoot)
+
+    const target = path.join(aliasRoot, 'hello.txt')
+    const result = await resolveBoundaryPath({
+      absolutePath: target,
+      rootPath: aliasRoot,
+      intent: 'read',
+      boundaryLabel: 'workspace',
+    })
+
+    expect(result.exists).toBe(true)
+    expect(result.kind).toBe('file')
+  })
+
+  it('sync version rejects escaping symlinks', () => {
+    const outsideFile = path.join(outside, 'secret.txt')
+    fs.writeFileSync(outsideFile, 'secret')
+
+    const linkPath = path.join(sandbox, 'escape-link')
+    fs.symlinkSync(outside, linkPath)
+
+    const target = path.join(linkPath, 'secret.txt')
+    expect(() =>
+      resolveBoundaryPathSync({
+        absolutePath: target,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).toThrow(/Symlink.*escapes sandbox root/)
+  })
+
+  describe('fuzz: 32 random paths with mixed symlinks', () => {
+    it('correctly classifies random safe and unsafe symlinks', async () => {
+      const safeDir = path.join(sandbox, 'safe-target')
+      await fsp.mkdir(safeDir, { recursive: true })
+      await fsp.writeFile(path.join(safeDir, 'ok.txt'), 'ok')
+
+      const unsafeTarget = path.join(outside, 'nope')
+      await fsp.mkdir(unsafeTarget, { recursive: true })
+
+      for (let i = 0; i < 32; i++) {
+        const isSafe = i % 2 === 0
+        const linkName = `fuzz-${i}-${crypto.randomBytes(4).toString('hex')}`
+        const linkPath = path.join(sandbox, linkName)
+
+        if (isSafe) {
+          await fsp.symlink(safeDir, linkPath)
+        } else {
+          await fsp.symlink(unsafeTarget, linkPath)
+        }
+
+        const target = path.join(linkPath, 'ok.txt')
+
+        if (isSafe) {
+          const result = await resolveBoundaryPath({
+            absolutePath: target,
+            rootPath: sandbox,
+            intent: 'read',
+            boundaryLabel: 'sandbox root',
+          })
+          expect(result.exists).toBe(true)
+        } else {
+          await expect(
+            resolveBoundaryPath({
+              absolutePath: target,
+              rootPath: sandbox,
+              intent: 'read',
+              boundaryLabel: 'sandbox root',
+            })
+          ).rejects.toThrow(/escapes sandbox root/)
+        }
+      }
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Hardlink tests
+// ---------------------------------------------------------------------------
+
+describe('hardlink checks', () => {
+  it('allows a normal file (nlink=1)', async () => {
+    const filePath = path.join(sandbox, 'normal.txt')
+    await fsp.writeFile(filePath, 'content')
+
+    const resolved = await resolveBoundaryPath({
+      absolutePath: filePath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    await expect(
+      assertNoHardlinkedFinalPath({
+        absolutePath: filePath,
+        boundaryLabel: 'sandbox root',
+        resolvedPath: resolved,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects a hard-linked file (nlink>1)', async () => {
+    const filePath = path.join(sandbox, 'original.txt')
+    await fsp.writeFile(filePath, 'content')
+
+    const hardlinkPath = path.join(sandbox, 'hardlink.txt')
+    await fsp.link(filePath, hardlinkPath)
+
+    const resolved = await resolveBoundaryPath({
+      absolutePath: hardlinkPath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    await expect(
+      assertNoHardlinkedFinalPath({
+        absolutePath: hardlinkPath,
+        boundaryLabel: 'sandbox root',
+        resolvedPath: resolved,
+      })
+    ).rejects.toThrow(/Hard-linked file.*escapes sandbox root/)
+  })
+
+  it('allows a non-existent file', async () => {
+    const filePath = path.join(sandbox, 'ghost.txt')
+
+    const resolved = await resolveBoundaryPath({
+      absolutePath: filePath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    await expect(
+      assertNoHardlinkedFinalPath({
+        absolutePath: filePath,
+        boundaryLabel: 'sandbox root',
+        resolvedPath: resolved,
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('allows hard-linked file when allowFinalHardlinkForUnlink is true', async () => {
+    const filePath = path.join(sandbox, 'original.txt')
+    await fsp.writeFile(filePath, 'content')
+
+    const hardlinkPath = path.join(sandbox, 'hardlink.txt')
+    await fsp.link(filePath, hardlinkPath)
+
+    const resolved = await resolveBoundaryPath({
+      absolutePath: hardlinkPath,
+      rootPath: sandbox,
+      intent: 'delete',
+      boundaryLabel: 'sandbox root',
+    })
+
+    await expect(
+      assertNoHardlinkedFinalPath({
+        absolutePath: hardlinkPath,
+        boundaryLabel: 'sandbox root',
+        resolvedPath: resolved,
+        policy: { allowFinalHardlinkForUnlink: true },
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it('sync version rejects hard-linked file', () => {
+    const filePath = path.join(sandbox, 'original.txt')
+    fs.writeFileSync(filePath, 'content')
+
+    const hardlinkPath = path.join(sandbox, 'hardlink.txt')
+    fs.linkSync(filePath, hardlinkPath)
+
+    const resolved = resolveBoundaryPathSync({
+      absolutePath: hardlinkPath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(() =>
+      assertNoHardlinkedFinalPathSync({
+        absolutePath: hardlinkPath,
+        boundaryLabel: 'sandbox root',
+        resolvedPath: resolved,
+      })
+    ).toThrow(/Hard-linked file.*escapes sandbox root/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Combined guard (assertNoPathAliasEscape)
+// ---------------------------------------------------------------------------
+
+describe('assertNoPathAliasEscape (combined)', () => {
+  it('allows normal file inside sandbox', async () => {
+    const filePath = path.join(sandbox, 'safe.txt')
+    await fsp.writeFile(filePath, 'safe')
+
+    const result = await assertNoPathAliasEscape({
+      absolutePath: filePath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(true)
+    expect(result.kind).toBe('file')
+  })
+
+  it('rejects ../ path traversal', async () => {
+    const escaped = path.resolve(sandbox, '..', 'outside', 'secret.txt')
+
+    await expect(
+      assertNoPathAliasEscape({
+        absolutePath: escaped,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).rejects.toThrow(/escapes sandbox root/)
+  })
+
+  it('rejects absolute path outside root', async () => {
+    const outsidePath = path.join(outside, 'nope.txt')
+    await fsp.writeFile(outsidePath, 'nope')
+
+    await expect(
+      assertNoPathAliasEscape({
+        absolutePath: outsidePath,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).rejects.toThrow(/escapes sandbox root/)
+  })
+
+  it('allows normal sub-path', async () => {
+    const subDir = path.join(sandbox, 'a', 'b', 'c')
+    await fsp.mkdir(subDir, { recursive: true })
+    const filePath = path.join(subDir, 'deep.txt')
+    await fsp.writeFile(filePath, 'deep')
+
+    const result = await assertNoPathAliasEscape({
+      absolutePath: filePath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(true)
+    expect(result.kind).toBe('file')
+  })
+
+  it('sync version works for normal files', () => {
+    const filePath = path.join(sandbox, 'sync-safe.txt')
+    fs.writeFileSync(filePath, 'ok')
+
+    const result = assertNoPathAliasEscapeSync({
+      absolutePath: filePath,
+      rootPath: sandbox,
+      intent: 'read',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(true)
+    expect(result.kind).toBe('file')
+  })
+
+  it('sync version rejects ../ traversal', () => {
+    const escaped = path.resolve(sandbox, '..', 'outside', 'secret.txt')
+
+    expect(() =>
+      assertNoPathAliasEscapeSync({
+        absolutePath: escaped,
+        rootPath: sandbox,
+        intent: 'read',
+        boundaryLabel: 'sandbox root',
+      })
+    ).toThrow(/escapes sandbox root/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. resolveBoundaryPath – missing path handling
+// ---------------------------------------------------------------------------
+
+describe('resolveBoundaryPath missing paths', () => {
+  it('returns kind=missing for non-existent file inside sandbox', async () => {
+    const result = await resolveBoundaryPath({
+      absolutePath: path.join(sandbox, 'no', 'such', 'file.txt'),
+      rootPath: sandbox,
+      intent: 'create',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(false)
+    expect(result.kind).toBe('missing')
+  })
+
+  it('sync returns kind=missing for non-existent file inside sandbox', () => {
+    const result = resolveBoundaryPathSync({
+      absolutePath: path.join(sandbox, 'nope.txt'),
+      rootPath: sandbox,
+      intent: 'create',
+      boundaryLabel: 'sandbox root',
+    })
+
+    expect(result.exists).toBe(false)
+    expect(result.kind).toBe('missing')
+  })
+})

--- a/src/main/utils/boundary-path.ts
+++ b/src/main/utils/boundary-path.ts
@@ -1,0 +1,349 @@
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { isPathInside, isNotFoundPathError, shortenPath } from './path-guards'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type BoundaryPathIntent = 'read' | 'write' | 'create' | 'delete' | 'stat'
+
+export interface BoundaryPathAliasPolicy {
+  allowFinalSymlinkForUnlink?: boolean
+  allowFinalHardlinkForUnlink?: boolean
+}
+
+export interface ResolvedBoundaryPath {
+  absolutePath: string
+  canonicalPath: string
+  rootPath: string
+  rootCanonicalPath: string
+  relativePath: string
+  exists: boolean
+  kind: 'missing' | 'file' | 'directory' | 'symlink' | 'other'
+}
+
+export interface ResolveBoundaryPathParams {
+  absolutePath: string
+  rootPath: string
+  intent: BoundaryPathIntent
+  boundaryLabel: string
+  policy?: BoundaryPathAliasPolicy
+}
+
+// ---------------------------------------------------------------------------
+// Error helper
+// ---------------------------------------------------------------------------
+
+class BoundaryEscapeError extends Error {
+  constructor(label: string, detail: string) {
+    super(`${detail} escapes ${label}`)
+    this.name = 'BoundaryEscapeError'
+  }
+}
+
+function throwEscape(label: string, kind: string, targetPath: string): never {
+  throw new BoundaryEscapeError(label, `${kind} at ${shortenPath(targetPath)}`)
+}
+
+// ---------------------------------------------------------------------------
+// resolvePathViaExistingAncestor
+// ---------------------------------------------------------------------------
+
+/**
+ * For a path that may not fully exist, walk upward to the nearest existing
+ * ancestor, resolve it via realpath, then re-append the missing tail segments.
+ */
+async function resolvePathViaExistingAncestor(targetPath: string): Promise<string> {
+  const missing: string[] = []
+  let cursor = targetPath
+  for (;;) {
+    try {
+      const real = await fsp.realpath(cursor)
+      return missing.reduceRight((acc, seg) => path.join(acc, seg), real)
+    } catch (err: unknown) {
+      if (!isNotFoundPathError(err)) throw err
+      missing.push(path.basename(cursor))
+      const parent = path.dirname(cursor)
+      if (parent === cursor) return targetPath
+      cursor = parent
+    }
+  }
+}
+
+function resolvePathViaExistingAncestorSync(targetPath: string): string {
+  const missing: string[] = []
+  let cursor = targetPath
+  for (;;) {
+    try {
+      const real = fs.realpathSync(cursor)
+      return missing.reduceRight((acc, seg) => path.join(acc, seg), real)
+    } catch (err: unknown) {
+      if (!isNotFoundPathError(err)) throw err
+      missing.push(path.basename(cursor))
+      const parent = path.dirname(cursor)
+      if (parent === cursor) return targetPath
+      cursor = parent
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Kind helper
+// ---------------------------------------------------------------------------
+
+function statsToKind(stats: fs.Stats): ResolvedBoundaryPath['kind'] {
+  if (stats.isSymbolicLink()) return 'symlink'
+  if (stats.isFile()) return 'file'
+  if (stats.isDirectory()) return 'directory'
+  return 'other'
+}
+
+// ---------------------------------------------------------------------------
+// Core algorithm (async)
+// ---------------------------------------------------------------------------
+
+export async function resolveBoundaryPath(
+  params: ResolveBoundaryPathParams
+): Promise<ResolvedBoundaryPath> {
+  const { absolutePath, rootPath, boundaryLabel, policy } = params
+
+  // --- Step 1: lexical fast-path ---
+  const lexicalOk = isPathInside(rootPath, absolutePath)
+
+  // --- Step 2: canonical root ---
+  let rootCanonical: string
+  try {
+    rootCanonical = await fsp.realpath(rootPath)
+  } catch {
+    rootCanonical = rootPath
+  }
+
+  // --- Step 3: if lexical check failed, try canonical ---
+  if (!lexicalOk) {
+    const targetCanonical = await resolvePathViaExistingAncestor(absolutePath)
+    if (!isPathInside(rootCanonical, targetCanonical)) {
+      throwEscape(boundaryLabel, 'Path', absolutePath)
+    }
+  }
+
+  // --- Step 4: split into segments ---
+  const relFromRoot = path.relative(rootPath, absolutePath)
+  const segments = relFromRoot.split(path.sep).filter(Boolean)
+
+  // --- Step 5: segment-by-segment walk ---
+  let lexicalCursor = rootPath
+  let canonicalCursor = rootCanonical
+  let preserveFinalSymlink = false
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    lexicalCursor = path.join(lexicalCursor, segment)
+
+    let stats: fs.Stats
+    try {
+      stats = await fsp.lstat(lexicalCursor)
+    } catch (err: unknown) {
+      if (isNotFoundPathError(err)) {
+        // Append remaining segments and do a boundary check
+        const remaining = segments.slice(i)
+        const tail = remaining.join(path.sep)
+        canonicalCursor = path.join(canonicalCursor, tail)
+
+        if (!isPathInside(rootCanonical, canonicalCursor)) {
+          throwEscape(boundaryLabel, 'Path', absolutePath)
+        }
+
+        return {
+          absolutePath,
+          canonicalPath: canonicalCursor,
+          rootPath,
+          rootCanonicalPath: rootCanonical,
+          relativePath: path.relative(rootCanonical, canonicalCursor),
+          exists: false,
+          kind: 'missing',
+        }
+      }
+      throw err
+    }
+
+    const isLastSegment = i === segments.length - 1
+
+    if (stats.isSymbolicLink()) {
+      if (isLastSegment && policy?.allowFinalSymlinkForUnlink) {
+        preserveFinalSymlink = true
+        canonicalCursor = path.join(canonicalCursor, segment)
+        break
+      }
+
+      // Resolve the link and check if it stays inside the boundary
+      const linkCanonical = await fsp.realpath(lexicalCursor)
+      if (!isPathInside(rootCanonical, linkCanonical)) {
+        throwEscape(boundaryLabel, `Symlink at ${shortenPath(lexicalCursor)}`, absolutePath)
+      }
+      canonicalCursor = linkCanonical
+    } else {
+      canonicalCursor = path.resolve(canonicalCursor, segment)
+      if (!isPathInside(rootCanonical, canonicalCursor)) {
+        throwEscape(boundaryLabel, 'Path', absolutePath)
+      }
+    }
+  }
+
+  // --- Step 6: final boundary check ---
+  if (!isPathInside(rootCanonical, canonicalCursor)) {
+    throwEscape(boundaryLabel, 'Path', absolutePath)
+  }
+
+  // Determine kind
+  let kind: ResolvedBoundaryPath['kind']
+  let exists: boolean
+  if (preserveFinalSymlink) {
+    kind = 'symlink'
+    exists = true
+  } else {
+    try {
+      const finalStats = await fsp.lstat(absolutePath)
+      kind = statsToKind(finalStats)
+      exists = true
+    } catch (err: unknown) {
+      if (isNotFoundPathError(err)) {
+        kind = 'missing'
+        exists = false
+      } else {
+        throw err
+      }
+    }
+  }
+
+  return {
+    absolutePath,
+    canonicalPath: canonicalCursor,
+    rootPath,
+    rootCanonicalPath: rootCanonical,
+    relativePath: path.relative(rootCanonical, canonicalCursor),
+    exists,
+    kind,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core algorithm (sync)
+// ---------------------------------------------------------------------------
+
+export function resolveBoundaryPathSync(
+  params: ResolveBoundaryPathParams
+): ResolvedBoundaryPath {
+  const { absolutePath, rootPath, boundaryLabel, policy } = params
+
+  const lexicalOk = isPathInside(rootPath, absolutePath)
+
+  let rootCanonical: string
+  try {
+    rootCanonical = fs.realpathSync(rootPath)
+  } catch {
+    rootCanonical = rootPath
+  }
+
+  if (!lexicalOk) {
+    const targetCanonical = resolvePathViaExistingAncestorSync(absolutePath)
+    if (!isPathInside(rootCanonical, targetCanonical)) {
+      throwEscape(boundaryLabel, 'Path', absolutePath)
+    }
+  }
+
+  const relFromRoot = path.relative(rootPath, absolutePath)
+  const segments = relFromRoot.split(path.sep).filter(Boolean)
+
+  let lexicalCursor = rootPath
+  let canonicalCursor = rootCanonical
+  let preserveFinalSymlink = false
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    lexicalCursor = path.join(lexicalCursor, segment)
+
+    let stats: fs.Stats
+    try {
+      stats = fs.lstatSync(lexicalCursor)
+    } catch (err: unknown) {
+      if (isNotFoundPathError(err)) {
+        const remaining = segments.slice(i)
+        const tail = remaining.join(path.sep)
+        canonicalCursor = path.join(canonicalCursor, tail)
+
+        if (!isPathInside(rootCanonical, canonicalCursor)) {
+          throwEscape(boundaryLabel, 'Path', absolutePath)
+        }
+
+        return {
+          absolutePath,
+          canonicalPath: canonicalCursor,
+          rootPath,
+          rootCanonicalPath: rootCanonical,
+          relativePath: path.relative(rootCanonical, canonicalCursor),
+          exists: false,
+          kind: 'missing',
+        }
+      }
+      throw err
+    }
+
+    const isLastSegment = i === segments.length - 1
+
+    if (stats.isSymbolicLink()) {
+      if (isLastSegment && policy?.allowFinalSymlinkForUnlink) {
+        preserveFinalSymlink = true
+        canonicalCursor = path.join(canonicalCursor, segment)
+        break
+      }
+
+      const linkCanonical = fs.realpathSync(lexicalCursor)
+      if (!isPathInside(rootCanonical, linkCanonical)) {
+        throwEscape(boundaryLabel, `Symlink at ${shortenPath(lexicalCursor)}`, absolutePath)
+      }
+      canonicalCursor = linkCanonical
+    } else {
+      canonicalCursor = path.resolve(canonicalCursor, segment)
+      if (!isPathInside(rootCanonical, canonicalCursor)) {
+        throwEscape(boundaryLabel, 'Path', absolutePath)
+      }
+    }
+  }
+
+  if (!isPathInside(rootCanonical, canonicalCursor)) {
+    throwEscape(boundaryLabel, 'Path', absolutePath)
+  }
+
+  let kind: ResolvedBoundaryPath['kind']
+  let exists: boolean
+  if (preserveFinalSymlink) {
+    kind = 'symlink'
+    exists = true
+  } else {
+    try {
+      const finalStats = fs.lstatSync(absolutePath)
+      kind = statsToKind(finalStats)
+      exists = true
+    } catch (err: unknown) {
+      if (isNotFoundPathError(err)) {
+        kind = 'missing'
+        exists = false
+      } else {
+        throw err
+      }
+    }
+  }
+
+  return {
+    absolutePath,
+    canonicalPath: canonicalCursor,
+    rootPath,
+    rootCanonicalPath: rootCanonical,
+    relativePath: path.relative(rootCanonical, canonicalCursor),
+    exists,
+    kind,
+  }
+}

--- a/src/main/utils/file-boundary.ts
+++ b/src/main/utils/file-boundary.ts
@@ -1,0 +1,42 @@
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { getSetting } from '../config/settings.config'
+import { assertNoPathAliasEscape } from './path-alias-guards'
+import type { BoundaryPathIntent } from './boundary-path'
+
+/**
+ * Central file-boundary guard used by both agent tool executors and IPC
+ * file handlers. Reads the user-configurable boundary root from settings
+ * (falls back to the user's home directory) and throws a
+ * BoundaryEscapeError when the resolved path escapes it.
+ *
+ * Returns the resolved absolute path for convenience.
+ */
+export async function guardFileBoundary(
+  filePath: string,
+  intent: BoundaryPathIntent
+): Promise<string> {
+  const customRoot = await getSetting('fileAccessBoundaryRoot')
+  const rootPath = customRoot || os.homedir()
+
+  let absolutePath: string
+  if (filePath.startsWith('~')) {
+    absolutePath = path.resolve(filePath.replace(/^~/, os.homedir()))
+  } else {
+    absolutePath = path.resolve(filePath)
+  }
+
+  await assertNoPathAliasEscape({
+    absolutePath,
+    rootPath,
+    intent,
+    boundaryLabel: 'file access boundary',
+    policy:
+      intent === 'delete'
+        ? { allowFinalSymlinkForUnlink: true }
+        : undefined,
+  })
+
+  return absolutePath
+}

--- a/src/main/utils/hardlink-guards.ts
+++ b/src/main/utils/hardlink-guards.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs'
+import * as fsp from 'node:fs/promises'
+
+import { isNotFoundPathError, shortenPath } from './path-guards'
+import type { ResolvedBoundaryPath, BoundaryPathAliasPolicy } from './boundary-path'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AssertNoHardlinkParams {
+  absolutePath: string
+  boundaryLabel: string
+  resolvedPath: ResolvedBoundaryPath
+  policy?: BoundaryPathAliasPolicy
+}
+
+// ---------------------------------------------------------------------------
+// Async
+// ---------------------------------------------------------------------------
+
+export async function assertNoHardlinkedFinalPath(
+  params: AssertNoHardlinkParams
+): Promise<void> {
+  const { absolutePath, boundaryLabel, resolvedPath, policy } = params
+
+  if (policy?.allowFinalHardlinkForUnlink) return
+
+  if (!resolvedPath.exists) return
+
+  try {
+    const stats = await fsp.stat(absolutePath)
+    if (stats.isFile() && stats.nlink > 1) {
+      throw new Error(
+        `Hard-linked file at ${shortenPath(absolutePath)} escapes ${boundaryLabel} ` +
+          `(nlink=${stats.nlink})`
+      )
+    }
+  } catch (err: unknown) {
+    if (isNotFoundPathError(err)) return
+    throw err
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync
+// ---------------------------------------------------------------------------
+
+export function assertNoHardlinkedFinalPathSync(
+  params: AssertNoHardlinkParams
+): void {
+  const { absolutePath, boundaryLabel, resolvedPath, policy } = params
+
+  if (policy?.allowFinalHardlinkForUnlink) return
+
+  if (!resolvedPath.exists) return
+
+  try {
+    const stats = fs.statSync(absolutePath)
+    if (stats.isFile() && stats.nlink > 1) {
+      throw new Error(
+        `Hard-linked file at ${shortenPath(absolutePath)} escapes ${boundaryLabel} ` +
+          `(nlink=${stats.nlink})`
+      )
+    }
+  } catch (err: unknown) {
+    if (isNotFoundPathError(err)) return
+    throw err
+  }
+}

--- a/src/main/utils/path-alias-guards.ts
+++ b/src/main/utils/path-alias-guards.ts
@@ -1,0 +1,69 @@
+import {
+  resolveBoundaryPath,
+  resolveBoundaryPathSync,
+  type BoundaryPathIntent,
+  type BoundaryPathAliasPolicy,
+  type ResolvedBoundaryPath,
+} from './boundary-path'
+import {
+  assertNoHardlinkedFinalPath,
+  assertNoHardlinkedFinalPathSync,
+} from './hardlink-guards'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AssertNoPathAliasEscapeParams {
+  absolutePath: string
+  rootPath: string
+  intent: BoundaryPathIntent
+  boundaryLabel: string
+  policy?: BoundaryPathAliasPolicy
+}
+
+// ---------------------------------------------------------------------------
+// Async
+// ---------------------------------------------------------------------------
+
+export async function assertNoPathAliasEscape(
+  params: AssertNoPathAliasEscapeParams
+): Promise<ResolvedBoundaryPath> {
+  const resolved = await resolveBoundaryPath(params)
+
+  if (params.policy?.allowFinalSymlinkForUnlink && resolved.kind === 'symlink') {
+    return resolved
+  }
+
+  await assertNoHardlinkedFinalPath({
+    absolutePath: params.absolutePath,
+    boundaryLabel: params.boundaryLabel,
+    resolvedPath: resolved,
+    policy: params.policy,
+  })
+
+  return resolved
+}
+
+// ---------------------------------------------------------------------------
+// Sync
+// ---------------------------------------------------------------------------
+
+export function assertNoPathAliasEscapeSync(
+  params: AssertNoPathAliasEscapeParams
+): ResolvedBoundaryPath {
+  const resolved = resolveBoundaryPathSync(params)
+
+  if (params.policy?.allowFinalSymlinkForUnlink && resolved.kind === 'symlink') {
+    return resolved
+  }
+
+  assertNoHardlinkedFinalPathSync({
+    absolutePath: params.absolutePath,
+    boundaryLabel: params.boundaryLabel,
+    resolvedPath: resolved,
+    policy: params.policy,
+  })
+
+  return resolved
+}

--- a/src/main/utils/path-guards.ts
+++ b/src/main/utils/path-guards.ts
@@ -1,0 +1,64 @@
+import * as path from 'node:path'
+import * as os from 'node:os'
+
+/**
+ * Strip Windows extended-length path prefix (\\?\) and normalize UNC paths.
+ */
+function stripWin32Prefix(p: string): string {
+  if (p.startsWith('\\\\?\\UNC\\')) {
+    return '\\\\' + p.slice(8)
+  }
+  if (p.startsWith('\\\\?\\')) {
+    return p.slice(4)
+  }
+  return p
+}
+
+/**
+ * Determine whether `target` is located inside (or equal to) `root`.
+ * Pure lexical check — no I/O. On win32 the comparison is case-insensitive
+ * and \\?\ / UNC prefixes are stripped before comparison.
+ */
+export function isPathInside(root: string, target: string): boolean {
+  let resolvedRoot = path.resolve(root)
+  let resolvedTarget = path.resolve(target)
+
+  if (process.platform === 'win32') {
+    resolvedRoot = stripWin32Prefix(resolvedRoot).toLowerCase()
+    resolvedTarget = stripWin32Prefix(resolvedTarget).toLowerCase()
+  }
+
+  if (resolvedTarget === resolvedRoot) return true
+
+  const rel = path.relative(resolvedRoot, resolvedTarget)
+  if (rel === '') return true
+  return !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+interface NodeErrnoLike {
+  code?: string
+}
+
+/**
+ * Return true when `err` is an ENOENT or ENOTDIR filesystem error —
+ * the two codes that indicate "path does not exist".
+ */
+export function isNotFoundPathError(err: unknown): boolean {
+  if (err === null || err === undefined) return false
+  if (typeof err !== 'object') return false
+  const code = (err as NodeErrnoLike).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+const homeDir = os.homedir()
+
+/**
+ * Replace the leading homedir portion of a path with `~` for
+ * friendlier error messages.
+ */
+export function shortenPath(p: string): string {
+  if (homeDir && p.startsWith(homeDir)) {
+    return '~' + p.slice(homeDir.length)
+  }
+  return p
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -130,6 +130,7 @@ interface AppSettings {
   showAgentActivity: boolean
   tavilyApiKey: string
   preventSleep: boolean
+  fileAccessBoundaryRoot: string
 }
 
 // Agent API interface

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -37,7 +37,7 @@ interface MessageAttachment {
 // App message type
 interface AppMessage {
   id: string
-  platform: 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu'
+  platform: 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu' | 'local'
   chatId?: string
   senderId?: string
   senderName: string
@@ -50,7 +50,7 @@ interface AppMessage {
 
 // Bot status type
 interface BotStatus {
-  platform: 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu'
+  platform: 'telegram' | 'whatsapp' | 'discord' | 'slack' | 'line' | 'feishu' | 'local'
   isConnected: boolean
   username?: string
   botName?: string
@@ -133,7 +133,7 @@ interface AppSettings {
   fileAccessBoundaryRoot: string
   bashToolEnabled: boolean
   bashToolRequireAuthorizedUser: boolean
-  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'>
+  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'local' | 'none'>
   bashToolAllowedSources: Array<'message' | 'proactive' | 'system' | 'service'>
 }
 
@@ -142,6 +142,16 @@ interface AgentApi {
   sendMessage: (message: string) => Promise<IpcResponse<string>>
   getHistory: () => Promise<IpcResponse<ConversationMessage[]>>
   clearHistory: () => Promise<IpcResponse>
+}
+
+interface LocalApi {
+  sendMessage: (message: string) => Promise<IpcResponse<AppMessage>>
+  getStatus: () => Promise<IpcResponse<BotStatus>>
+  getMessages: (limit?: number) => Promise<IpcResponse<AppMessage[]>>
+  clearMessages: () => Promise<IpcResponse>
+  onNewMessage: (callback: (message: AppMessage) => void) => () => void
+  onStatusChanged: (callback: (status: BotStatus) => void) => () => void
+  onMessagesRefresh: (callback: () => void) => () => void
 }
 
 // File API interface
@@ -488,6 +498,7 @@ declare global {
   interface Window {
     electron: ElectronAPI
     agent: AgentApi
+    local: LocalApi
     file: FileApi
     telegram: TelegramApi
     discord: DiscordApi

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -131,6 +131,10 @@ interface AppSettings {
   tavilyApiKey: string
   preventSleep: boolean
   fileAccessBoundaryRoot: string
+  bashToolEnabled: boolean
+  bashToolRequireAuthorizedUser: boolean
+  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'>
+  bashToolAllowedSources: Array<'message' | 'proactive' | 'system' | 'service'>
 }
 
 // Agent API interface

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,25 @@ const agentApi = {
   clearHistory: () => ipcRenderer.invoke('agent:clear-history')
 }
 
+const localApi = {
+  sendMessage: (message: string) => ipcRenderer.invoke('local:send-message', message),
+  getStatus: () => ipcRenderer.invoke('local:status'),
+  getMessages: (limit?: number) => ipcRenderer.invoke('local:get-messages', limit),
+  clearMessages: () => ipcRenderer.invoke('local:clear-messages'),
+  onNewMessage: (callback: (message: unknown) => void) => {
+    ipcRenderer.on('local:new-message', (_event, message) => callback(message))
+    return () => ipcRenderer.removeAllListeners('local:new-message')
+  },
+  onStatusChanged: (callback: (status: unknown) => void) => {
+    ipcRenderer.on('local:status-changed', (_event, status) => callback(status))
+    return () => ipcRenderer.removeAllListeners('local:status-changed')
+  },
+  onMessagesRefresh: (callback: () => void) => {
+    ipcRenderer.on('local:messages-refresh', () => callback())
+    return () => ipcRenderer.removeAllListeners('local:messages-refresh')
+  }
+}
+
 // File API
 const fileApi = {
   read: (path: string) => ipcRenderer.invoke('file:read', path),
@@ -262,6 +281,7 @@ if (process.contextIsolated) {
   try {
     contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('agent', agentApi)
+    contextBridge.exposeInMainWorld('local', localApi)
     contextBridge.exposeInMainWorld('file', fileApi)
     contextBridge.exposeInMainWorld('telegram', telegramApi)
     contextBridge.exposeInMainWorld('discord', discordApi)
@@ -284,6 +304,8 @@ if (process.contextIsolated) {
   window.electron = electronAPI
   // @ts-ignore (define in dts)
   window.agent = agentApi
+  // @ts-ignore (define in dts)
+  window.local = localApi
   // @ts-ignore (define in dts)
   window.file = fileApi
   // @ts-ignore (define in dts)

--- a/src/renderer/src/App/memu.impl.tsx
+++ b/src/renderer/src/App/memu.impl.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Sidebar, Header } from '../components/Layout'
+import { LocalChatView } from '../components/LocalChat/LocalChatView'
 import { TelegramView } from '../components/Telegram'
 import { DiscordView } from '../components/Discord'
 import { WhatsAppView } from '../components/WhatsApp'
@@ -17,19 +18,19 @@ import { AgentActivityPanel } from '../components/AgentActivity'
 import { useThemeStore, applyTheme } from '../stores/themeStore'
 import { appIcon } from '../assets'
 
-type NavItem = 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'settings'
+type NavItem = 'local' | 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'settings'
 type AppNavItem = Exclude<NavItem, 'settings'>
 
 const LAST_APP_TAB_KEY = 'memu-last-app-tab'
 
-// Get saved tab or default to telegram
+// Get saved tab or default to local chat
 function getSavedAppTab(): AppNavItem {
   const saved = localStorage.getItem(LAST_APP_TAB_KEY)
-  const validTabs: AppNavItem[] = ['telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu']
+  const validTabs: AppNavItem[] = ['local', 'telegram', 'discord', 'whatsapp', 'slack', 'line', 'feishu']
   if (saved && validTabs.includes(saved as AppNavItem)) {
     return saved as AppNavItem
   }
-  return 'telegram'
+  return 'local'
 }
 
 interface StartupStatus {
@@ -95,6 +96,15 @@ export function MemuApp(): JSX.Element {
 
   const getHeaderInfo = () => {
     switch (activeNav) {
+      case 'local':
+        return {
+          title: t('nav.local'),
+          subtitle: t('header.aiAssistant'),
+          showTelegramStatus: false,
+          showDiscordStatus: false,
+          showSlackStatus: false,
+          showFeishuStatus: false
+        }
       case 'telegram':
         return {
           title: 'Telegram',
@@ -226,6 +236,7 @@ export function MemuApp(): JSX.Element {
         />
 
         <main className="flex-1 overflow-hidden flex">
+          {activeNav === 'local' && <LocalChatView />}
           {activeNav === 'telegram' && <TelegramView />}
           {activeNav === 'discord' && <DiscordView />}
           {activeNav === 'whatsapp' && <WhatsAppView />}

--- a/src/renderer/src/components/Layout/Sidebar/memu.impl.tsx
+++ b/src/renderer/src/components/Layout/Sidebar/memu.impl.tsx
@@ -2,7 +2,7 @@
  * Sidebar - Memu Implementation
  * Shows all messaging platforms (Telegram, Discord, Slack, Feishu)
  */
-import { Settings, Sun, Moon, Monitor } from 'lucide-react'
+import { Settings, Sun, Moon, Monitor, MessageSquare } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useThemeStore, type ThemeMode } from '../../../stores/themeStore'
 import { appIcon } from '../../../assets'
@@ -41,6 +41,19 @@ export function MemuSidebar({ activeNav, onNavChange }: MemuSidebarProps): JSX.E
 
       {/* Main Navigation */}
       <nav className="flex-1 flex flex-col items-center pt-4 gap-2">
+        {/* Local Chat */}
+        <button
+          onClick={() => onNavChange('local')}
+          title={t('nav.local')}
+          className={`w-11 h-11 rounded-xl flex items-center justify-center transition-all duration-200 ${
+            activeNav === 'local'
+              ? 'bg-gradient-to-br from-[#0f766e] to-[#14b8a6] text-white shadow-lg shadow-[#14b8a6]/25'
+              : 'bg-[var(--bg-card)] text-[var(--text-muted)] hover:text-[#0f766e] hover:bg-[var(--bg-card-solid)] hover:shadow-md'
+          }`}
+        >
+          <MessageSquare className="w-[18px] h-[18px]" />
+        </button>
+
         {/* Telegram */}
         <button
           onClick={() => onNavChange('telegram')}

--- a/src/renderer/src/components/Layout/Sidebar/types.ts
+++ b/src/renderer/src/components/Layout/Sidebar/types.ts
@@ -3,7 +3,7 @@
  */
 
 // Memu navigation items (all platforms)
-export type MemuNavItem = 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'settings'
+export type MemuNavItem = 'local' | 'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'settings'
 
 // Union type for all possible nav items
 export type NavItem = MemuNavItem

--- a/src/renderer/src/components/LocalChat/LocalChatView.tsx
+++ b/src/renderer/src/components/LocalChat/LocalChatView.tsx
@@ -1,0 +1,117 @@
+import { useState, type KeyboardEvent } from 'react'
+import { Loader2, MessageSquare, SendHorizontal, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { UnifiedMessageList, platformColors } from '../Shared'
+import { toast } from '../Toast'
+
+export function LocalChatView(): JSX.Element {
+  const { t } = useTranslation()
+  const [input, setInput] = useState('')
+  const [isSending, setIsSending] = useState(false)
+  const [isClearing, setIsClearing] = useState(false)
+
+  const handleSend = async (): Promise<void> => {
+    const message = input.trim()
+    if (!message || isSending) return
+
+    setInput('')
+    setIsSending(true)
+
+    try {
+      const result = await window.local.sendMessage(message)
+      if (!result.success) {
+        setInput(message)
+        toast.error(result.error || t('errors.messageFailed'))
+      }
+    } catch (error) {
+      setInput(message)
+      toast.error(error instanceof Error ? error.message : t('errors.messageFailed'))
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  const handleClear = async (): Promise<void> => {
+    if (isClearing) return
+
+    setIsClearing(true)
+    try {
+      const result = await window.local.clearMessages()
+      if (result.success) {
+        toast.success(t('localChat.cleared'))
+      } else {
+        toast.error(result.error || t('errors.deleteFailed'))
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('errors.deleteFailed'))
+    } finally {
+      setIsClearing(false)
+    }
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      void handleSend()
+    }
+  }
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <UnifiedMessageList
+        api={window.local}
+        colors={platformColors.local}
+        emptyIcon={MessageSquare}
+        emptyTitle={t('messages.empty.title', 'No Messages Yet')}
+        emptyDescription={t('messages.empty.local')}
+      />
+
+      <div className="border-t border-[var(--border-color)] bg-[var(--glass-bg)] backdrop-blur-xl">
+        <div className="flex items-center justify-between px-4 pt-3 pb-2">
+          <p className="text-xs text-[var(--text-muted)]">{t('localChat.helper')}</p>
+          <button
+            type="button"
+            onClick={() => void handleClear()}
+            disabled={isSending || isClearing}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs text-[var(--text-muted)] hover:bg-[var(--bg-card)] hover:text-[var(--text-primary)] disabled:opacity-50"
+          >
+            {isClearing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+            <span>{isClearing ? t('common.clearing') : t('localChat.clearHistory')}</span>
+          </button>
+        </div>
+
+        <div className="px-4 pb-4">
+          <div className="flex items-end gap-3 rounded-2xl border border-[var(--border-color)] bg-[var(--bg-card)] px-3 py-3 shadow-sm">
+            <textarea
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={t('messages.typeMessage')}
+              disabled={isSending || isClearing}
+              rows={1}
+              className="min-h-[44px] max-h-40 flex-1 resize-none bg-transparent px-1 py-2 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+            />
+
+            <button
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={!input.trim() || isSending || isClearing}
+              className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-[#0f766e] to-[#14b8a6] text-white shadow-lg shadow-[#14b8a6]/20 transition disabled:cursor-not-allowed disabled:opacity-50"
+              title={t('messages.send')}
+            >
+              {isSending ? (
+                <Loader2 className="w-4.5 h-4.5 animate-spin" />
+              ) : (
+                <SendHorizontal className="w-4.5 h-4.5" />
+              )}
+            </button>
+          </div>
+
+          <p className="mt-2 text-[11px] text-[var(--text-muted)]">
+            {isSending ? t('messages.thinking') : t('localChat.enterHint')}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Settings/SecuritySettings.tsx
+++ b/src/renderer/src/components/Settings/SecuritySettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Shield, Key, Copy, RefreshCw, Loader2, Check } from 'lucide-react'
+import { Shield, Key, Copy, RefreshCw, Loader2, Check, FolderLock, RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from '../../stores/toastStore'
 
@@ -16,6 +16,38 @@ export function SecuritySettings(): JSX.Element {
   const [loading, setLoading] = useState(false)
   const [copied, setCopied] = useState(false)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const [boundaryRoot, setBoundaryRoot] = useState('')
+  const [boundaryLoading, setBoundaryLoading] = useState(true)
+  const [boundarySaving, setBoundarySaving] = useState(false)
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const result = await window.settings.get()
+        if (result.success && result.data) {
+          setBoundaryRoot(result.data.fileAccessBoundaryRoot ?? '')
+        }
+      } catch { /* ignore */ }
+      setBoundaryLoading(false)
+    })()
+  }, [])
+
+  const saveBoundaryRoot = async (value: string) => {
+    setBoundarySaving(true)
+    try {
+      const result = await window.settings.save({ fileAccessBoundaryRoot: value })
+      if (result.success) {
+        setBoundaryRoot(value)
+        toast.success(t('common.saved'))
+      } else {
+        toast.error(result.error || t('settings.saveError'))
+      }
+    } catch {
+      toast.error(t('settings.saveError'))
+    }
+    setBoundarySaving(false)
+  }
 
   // Countdown timer
   useEffect(() => {
@@ -165,6 +197,57 @@ export function SecuritySettings(): JSX.Element {
               </>
             )}
           </button>
+        </div>
+
+        {/* File Access Boundary Section */}
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-500/20 to-teal-500/20 flex items-center justify-center">
+              <FolderLock className="w-5 h-5 text-emerald-500" />
+            </div>
+            <div>
+              <h4 className="text-[13px] font-medium text-[var(--text-primary)]">
+                {t('settings.security.fileBoundary.title')}
+              </h4>
+              <p className="text-[11px] text-[var(--text-muted)] mt-0.5">
+                {t('settings.security.fileBoundary.description')}
+              </p>
+            </div>
+          </div>
+
+          {boundaryLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="w-4 h-4 text-[var(--primary)] animate-spin" />
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={boundaryRoot}
+                  onChange={(e) => setBoundaryRoot(e.target.value)}
+                  placeholder={t('settings.security.fileBoundary.placeholder')}
+                  className="flex-1 px-3 py-2.5 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/30 focus:border-[var(--primary)] transition-all"
+                  onBlur={() => saveBoundaryRoot(boundaryRoot)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') saveBoundaryRoot(boundaryRoot)
+                  }}
+                  disabled={boundarySaving}
+                />
+                <button
+                  onClick={() => saveBoundaryRoot('')}
+                  disabled={boundarySaving || boundaryRoot === ''}
+                  title={t('settings.security.fileBoundary.resetDefault')}
+                  className="p-2.5 rounded-xl border border-[var(--border-color)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:border-[var(--text-primary)] transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <RotateCcw className="w-4 h-4" />
+                </button>
+              </div>
+              <p className="text-[10px] text-[var(--text-muted)] mt-2 opacity-70">
+                {t('settings.security.fileBoundary.hint')}
+              </p>
+            </>
+          )}
         </div>
 
         {/* Security Notes */}

--- a/src/renderer/src/components/Settings/shared.tsx
+++ b/src/renderer/src/components/Settings/shared.tsx
@@ -83,7 +83,7 @@ export interface AppSettings {
   fileAccessBoundaryRoot: string
   bashToolEnabled: boolean
   bashToolRequireAuthorizedUser: boolean
-  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'>
+  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'local' | 'none'>
   bashToolAllowedSources: Array<'message' | 'proactive' | 'system' | 'service'>
 }
 

--- a/src/renderer/src/components/Settings/shared.tsx
+++ b/src/renderer/src/components/Settings/shared.tsx
@@ -80,6 +80,7 @@ export interface AppSettings {
   feishuAutoConnect: boolean
   language: string
   tavilyApiKey: string
+  fileAccessBoundaryRoot: string
 }
 
 // Portal target ID — used by SettingsView containers

--- a/src/renderer/src/components/Settings/shared.tsx
+++ b/src/renderer/src/components/Settings/shared.tsx
@@ -81,6 +81,10 @@ export interface AppSettings {
   language: string
   tavilyApiKey: string
   fileAccessBoundaryRoot: string
+  bashToolEnabled: boolean
+  bashToolRequireAuthorizedUser: boolean
+  bashToolAllowedPlatforms: Array<'telegram' | 'discord' | 'whatsapp' | 'slack' | 'line' | 'feishu' | 'none'>
+  bashToolAllowedSources: Array<'message' | 'proactive' | 'system' | 'service'>
 }
 
 // Portal target ID — used by SettingsView containers

--- a/src/renderer/src/components/Shared/platformColors.ts
+++ b/src/renderer/src/components/Shared/platformColors.ts
@@ -4,6 +4,13 @@ import { ThemeColors } from './MessageBubble'
  * Platform theme colors configuration
  */
 export const platformColors: Record<string, ThemeColors> = {
+  local: {
+    primary: '#0f766e',
+    primaryLight: '#2dd4bf',
+    primaryDark: '#5eead4',
+    secondary: '#64748b',
+    secondaryDark: '#94a3b8'
+  },
   telegram: {
     primary: '#2596D1',
     primaryLight: '#7DCBF7',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11,6 +11,7 @@
     }
   },
   "nav": {
+    "local": "Local Chat",
     "telegram": "Telegram",
     "discord": "Discord",
     "whatsapp": "WhatsApp",
@@ -515,8 +516,15 @@
       "whatsapp": "Connect to WhatsApp to start chatting.",
       "slack": "Message the bot in Slack to start chatting.",
       "line": "Connect your Line bot to start chatting.",
-      "feishu": "Connect your bot and start chatting on Feishu."
+      "feishu": "Connect your bot and start chatting on Feishu.",
+      "local": "Talk to memU bot directly inside the desktop app."
     }
+  },
+  "localChat": {
+    "helper": "Local chat keeps history and feeds the existing memory pipeline.",
+    "enterHint": "Press Enter to send, Shift + Enter for a new line.",
+    "clearHistory": "Clear local chat",
+    "cleared": "Local chat cleared"
   },
   "status": {
     "online": "Online",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -253,7 +253,14 @@
       "viewBoundUsers": "View Bound Users",
       "unbind": "Unbind",
       "unbindConfirm": "Are you sure you want to unbind this user?",
-      "boundAt": "Bound at"
+      "boundAt": "Bound at",
+      "fileBoundary": {
+        "title": "File Access Boundary",
+        "description": "Restrict AI agent file operations to a specific directory",
+        "placeholder": "Leave empty to use home directory",
+        "resetDefault": "Reset to Default",
+        "hint": "Empty = user home directory. The AI agent can only read, write, and delete files within this boundary."
+      }
     },
     "model": {
       "title": "AI Model",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11,6 +11,7 @@
     }
   },
   "nav": {
+    "local": "ローカルチャット",
     "telegram": "Telegram",
     "discord": "Discord",
     "whatsapp": "WhatsApp",
@@ -494,8 +495,15 @@
       "whatsapp": "WhatsApp に接続してチャットを始めましょう。",
       "slack": "Slack でボットにメッセージを送ってチャットを始めましょう。",
       "line": "Line ボットを接続してチャットを始めましょう。",
-      "feishu": "ボットを接続して Feishu でチャットを始めましょう。"
+      "feishu": "ボットを接続して Feishu でチャットを始めましょう。",
+      "local": "デスクトップアプリ内で memU bot と直接会話します。"
     }
+  },
+  "localChat": {
+    "helper": "ローカルチャットは履歴を保存し、既存の記憶パイプラインにも流れます。",
+    "enterHint": "Enter で送信、Shift + Enter で改行。",
+    "clearHistory": "ローカルチャットをクリア",
+    "cleared": "ローカルチャットをクリアしました"
   },
   "status": {
     "online": "オンライン",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -253,7 +253,14 @@
       "viewBoundUsers": "バインド済みユーザーを表示",
       "unbind": "バインド解除",
       "unbindConfirm": "このユーザーのバインドを解除しますか？",
-      "boundAt": "バインド日時"
+      "boundAt": "バインド日時",
+      "fileBoundary": {
+        "title": "ファイルアクセス境界",
+        "description": "AIエージェントのファイル操作を特定のディレクトリに制限",
+        "placeholder": "空欄でホームディレクトリを使用",
+        "resetDefault": "デフォルトにリセット",
+        "hint": "空欄 = ユーザーホームディレクトリ。AIエージェントはこの境界内でのみファイルの読み取り、書き込み、削除が可能です。"
+      }
     },
     "model": {
       "title": "AI モデル",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -253,7 +253,14 @@
       "viewBoundUsers": "查看已绑定用户",
       "unbind": "解绑",
       "unbindConfirm": "确定要解绑此用户吗？",
-      "boundAt": "绑定时间"
+      "boundAt": "绑定时间",
+      "fileBoundary": {
+        "title": "文件访问边界",
+        "description": "限制 AI 助手的文件操作范围",
+        "placeholder": "留空则使用用户主目录",
+        "resetDefault": "重置为默认",
+        "hint": "留空 = 用户主目录。AI 助手只能在此边界内读取、写入和删除文件。"
+      }
     },
     "model": {
       "title": "AI 模型",

--- a/src/renderer/src/i18n/locales/zh-CN.json
+++ b/src/renderer/src/i18n/locales/zh-CN.json
@@ -11,6 +11,7 @@
     }
   },
   "nav": {
+    "local": "本地聊天",
     "telegram": "Telegram",
     "discord": "Discord",
     "whatsapp": "WhatsApp",
@@ -513,8 +514,15 @@
       "whatsapp": "连接 WhatsApp 开始聊天。",
       "slack": "在 Slack 中给机器人发消息开始聊天。",
       "line": "连接 Line 机器人开始聊天。",
-      "feishu": "连接机器人，在飞书上开始聊天。"
+      "feishu": "连接机器人，在飞书上开始聊天。",
+      "local": "直接在桌面端和 memU bot 对话。"
     }
+  },
+  "localChat": {
+    "helper": "本地聊天会保存历史，并接入现有记忆链路。",
+    "enterHint": "按 Enter 发送，Shift + Enter 换行。",
+    "clearHistory": "清空本地聊天",
+    "cleared": "本地聊天已清空"
   },
   "status": {
     "online": "在线",


### PR DESCRIPTION
## Summary
- Add a desktop-only Local Chat entry so users can talk to memU bot directly inside the app
- Persist local chat history across app restarts
- Route local chat messages through the existing agent and memory pipeline
- Introduce a shared file access boundary guard for file-related operations
- Restrict bash tool execution by platform/source settings and authorization checks

## Why
- Provide a first-party chat surface without requiring external messaging platforms
- Make the core conversation and memory flow easier to use, test, and demo locally
- Tighten safety controls around file access and bash execution while expanding local capabilities

## Notes for reviewers
- This PR includes prerequisite infrastructure/security changes in addition to the Local Chat feature
- The non-UI changes are intentional and support safer tool execution in the desktop app
- If helpful, review in this order: file boundary enforcement, bash access control, then Local Chat

## Test plan
- Launch the app and verify Local Chat is available and selected by default
- Send a message and verify both user and assistant messages render correctly
- Restart the app and verify local chat history is restored
- Clear local chat history and verify the message list refreshes correctly
- Verify file operations are rejected outside the configured boundary
- Verify bash execution is denied in disallowed contexts and allowed only when settings permit