### PR TITLE
Add local controlled memory management UI

### DIFF
--- a/src/main/apps/discord/bot.service.ts
+++ b/src/main/apps/discord/bot.service.ts
@@ -450,7 +450,7 @@ export class DiscordBotService {
       }
 
       // Get response from Agent with Discord-specific tools
-      const response = await agentService.processMessage(fullMessage, 'discord', imageUrls, undefined, {
+      const response = await agentService.processMessage(fullMessage, 'discord', imageUrls, undefined, undefined, {
         source: 'message',
         userId: originalMessage.author.id
       })

--- a/src/main/apps/line/bot.service.ts
+++ b/src/main/apps/line/bot.service.ts
@@ -180,7 +180,7 @@ export class LineBotService {
         return
       }
 
-      const response = await agentService.processMessage(userMessage, 'line', [], undefined, {
+      const response = await agentService.processMessage(userMessage, 'line', [], undefined, undefined, {
         source: 'message',
         userId
       })

--- a/src/main/apps/local/local.service.ts
+++ b/src/main/apps/local/local.service.ts
@@ -84,7 +84,7 @@ export class LocalChatService {
       return { success: true, data: userMessage }
     }
 
-    const response = await agentService.processMessage(trimmed, 'local', [], sessionId, {
+    const response = await agentService.processMessage(trimmed, 'local', [], sessionId, undefined, {
       source: 'message',
       isAuthorizedUser: true,
       userId: 'local-user'

--- a/src/main/apps/slack/bot.service.ts
+++ b/src/main/apps/slack/bot.service.ts
@@ -508,7 +508,7 @@ export class SlackBotService {
         return
       }
 
-      const response = await agentService.processMessage(fullMessage, 'slack', imageUrls, undefined, {
+      const response = await agentService.processMessage(fullMessage, 'slack', imageUrls, undefined, undefined, {
         source: 'message',
         userId
       })

--- a/src/main/apps/whatsapp/bot.service.ts
+++ b/src/main/apps/whatsapp/bot.service.ts
@@ -167,7 +167,7 @@ export class WhatsAppBotService {
         return
       }
 
-      const response = await agentService.processMessage(userMessage, 'whatsapp', [], undefined, {
+      const response = await agentService.processMessage(userMessage, 'whatsapp', [], undefined, undefined, {
         source: 'message',
         userId
       })

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -15,6 +15,7 @@ import { setupLLMHandlers } from './llm.handlers'
 import { registerSkillsHandlers } from './skills.handlers'
 import { setupServiceHandlers } from './service.handlers'
 import { setupUpdaterHandlers } from './updater.handlers'
+import { setupMemoryHandlers } from './memory.handlers'
 import { guardFileBoundary } from '../utils/file-boundary'
 import type { IpcResponse, FileInfo } from '../types'
 
@@ -38,6 +39,7 @@ export async function setupIpcHandlers(): Promise<void> {
   registerSkillsHandlers()
   setupServiceHandlers()
   setupUpdaterHandlers()
+  setupMemoryHandlers()
 }
 
 /**
@@ -49,7 +51,7 @@ function setupAgentHandlers(): void {
     'agent:send-message',
     async (_event, message: string): Promise<IpcResponse<string>> => {
       try {
-        const response = await agentService.processMessage(message, 'none', [], undefined, {
+        const response = await agentService.processMessage(message, 'none', [], undefined, undefined, {
           source: 'system'
         })
 

--- a/src/main/ipc/memory.handlers.ts
+++ b/src/main/ipc/memory.handlers.ts
@@ -1,0 +1,343 @@
+import { ipcMain } from 'electron'
+import type { IpcResponse } from '../types'
+import { localMemoryControlService, type DoNotRememberInput } from '../services/local-memory-control.service'
+import type {
+  CreateLocalMemoryInput,
+  ExplainedLocalMemoryItem,
+  LocalMemoryItem,
+  LocalMemoryListFilters,
+  MemoryEventRecord,
+  MemoryProvenance,
+  MemoryRetrievalResult,
+  MemorySearchFilters,
+  UpdateLocalMemoryInput,
+  MemorySensitivityLevel,
+  MemoryStatus,
+  MemoryUserControl,
+  MemoryConflictState,
+} from '../services/memory/local-memory.store'
+
+const MEMORY_SENSITIVITY_LEVELS: readonly MemorySensitivityLevel[] = ['normal', 'work', 'sensitive']
+const MEMORY_STATUSES: readonly MemoryStatus[] = ['active', 'archived', 'deleted']
+const MEMORY_USER_CONTROLS: readonly MemoryUserControl[] = ['auto', 'remember', 'dont_remember', 'modified', 'deleted', 'paused']
+const MEMORY_CONFLICT_STATES: readonly MemoryConflictState[] = ['none', 'potential', 'confirmed']
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function assertNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${fieldName} must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function optionalNullableString(value: unknown, fieldName: string): string | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string or null`)
+  }
+  return value
+}
+
+function optionalNumber(value: unknown, fieldName: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${fieldName} must be a finite number`)
+  }
+  return value
+}
+
+function optionalEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fieldName: string
+): T | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new Error(`${fieldName} must be one of: ${allowed.join(', ')}`)
+  }
+  return value as T
+}
+
+function sanitizeCreateMemoryInput(input: unknown): CreateLocalMemoryInput {
+  if (!isRecord(input)) throw new Error('memory input must be an object')
+
+  return {
+    id: optionalNullableString(input.id, 'id') ?? undefined,
+    content: assertNonEmptyString(input.content, 'content'),
+    memory_type: assertNonEmptyString(input.memory_type, 'memory_type'),
+    source_platform: optionalNullableString(input.source_platform, 'source_platform'),
+    source_excerpt: optionalNullableString(input.source_excerpt, 'source_excerpt'),
+    confidence: optionalNumber(input.confidence, 'confidence'),
+    importance: optionalNumber(input.importance, 'importance'),
+    sensitivity_level: optionalEnum(input.sensitivity_level, MEMORY_SENSITIVITY_LEVELS, 'sensitivity_level'),
+    retention_until: input.retention_until === null ? null : optionalNumber(input.retention_until, 'retention_until'),
+    status: optionalEnum(input.status, MEMORY_STATUSES, 'status'),
+    user_control: optionalEnum(input.user_control, MEMORY_USER_CONTROLS, 'user_control'),
+    why_stored: optionalNullableString(input.why_stored, 'why_stored'),
+    conflict_state: optionalEnum(input.conflict_state, MEMORY_CONFLICT_STATES, 'conflict_state'),
+    conflict_notes: optionalNullableString(input.conflict_notes, 'conflict_notes'),
+  }
+}
+
+function sanitizeDoNotRememberInput(input: unknown): DoNotRememberInput {
+  if (!isRecord(input)) throw new Error('do-not-remember input must be an object')
+
+  return {
+    content: assertNonEmptyString(input.content, 'content'),
+    memory_type: typeof input.memory_type === 'string' ? input.memory_type : undefined,
+    source_platform: optionalNullableString(input.source_platform, 'source_platform'),
+    source_excerpt: optionalNullableString(input.source_excerpt, 'source_excerpt'),
+    sensitivity_level: optionalEnum(input.sensitivity_level, MEMORY_SENSITIVITY_LEVELS, 'sensitivity_level'),
+    reason: optionalNullableString(input.reason, 'reason'),
+  }
+}
+
+function sanitizeUpdateMemoryInput(input: unknown): UpdateLocalMemoryInput {
+  if (!isRecord(input)) throw new Error('memory update input must be an object')
+
+  return {
+    content: typeof input.content === 'string' ? input.content : undefined,
+    memory_type: typeof input.memory_type === 'string' ? input.memory_type : undefined,
+    source_platform: optionalNullableString(input.source_platform, 'source_platform'),
+    source_excerpt: optionalNullableString(input.source_excerpt, 'source_excerpt'),
+    confidence: optionalNumber(input.confidence, 'confidence'),
+    importance: optionalNumber(input.importance, 'importance'),
+    sensitivity_level: optionalEnum(input.sensitivity_level, MEMORY_SENSITIVITY_LEVELS, 'sensitivity_level'),
+    retention_until: input.retention_until === null ? null : optionalNumber(input.retention_until, 'retention_until'),
+    status: optionalEnum(input.status, MEMORY_STATUSES, 'status'),
+    user_control: optionalEnum(input.user_control, MEMORY_USER_CONTROLS, 'user_control'),
+    why_stored: optionalNullableString(input.why_stored, 'why_stored'),
+    conflict_state: optionalEnum(input.conflict_state, MEMORY_CONFLICT_STATES, 'conflict_state'),
+    conflict_notes: optionalNullableString(input.conflict_notes, 'conflict_notes'),
+  }
+}
+
+function sanitizeSearchFilters(input: unknown): MemorySearchFilters {
+  if (input === undefined) return {}
+  if (!isRecord(input)) throw new Error('memory search filters must be an object')
+
+  return {
+    query: typeof input.query === 'string' ? input.query : undefined,
+    limit: optionalNumber(input.limit, 'limit'),
+    include_archived: typeof input.include_archived === 'boolean' ? input.include_archived : undefined,
+    created_after: optionalNumber(input.created_after, 'created_after'),
+    created_before: optionalNumber(input.created_before, 'created_before'),
+    updated_after: optionalNumber(input.updated_after, 'updated_after'),
+    updated_before: optionalNumber(input.updated_before, 'updated_before'),
+    min_confidence: optionalNumber(input.min_confidence, 'min_confidence'),
+    min_importance: optionalNumber(input.min_importance, 'min_importance'),
+    exclude_sensitive: typeof input.exclude_sensitive === 'boolean' ? input.exclude_sensitive : undefined,
+    status: optionalEnum(input.status, MEMORY_STATUSES, 'status'),
+    memory_type: typeof input.memory_type === 'string' ? input.memory_type : undefined,
+    source_platform: typeof input.source_platform === 'string' ? input.source_platform : undefined,
+    sensitivity_level: optionalEnum(input.sensitivity_level, MEMORY_SENSITIVITY_LEVELS, 'sensitivity_level'),
+    user_control: optionalEnum(input.user_control, MEMORY_USER_CONTROLS, 'user_control'),
+    conflict_state: optionalEnum(input.conflict_state, MEMORY_CONFLICT_STATES, 'conflict_state'),
+  }
+}
+
+function sanitizeListFilters(input: unknown): LocalMemoryListFilters {
+  if (input === undefined) return {}
+  if (!isRecord(input)) throw new Error('memory list filters must be an object')
+
+  return {
+    status: optionalEnum(input.status, MEMORY_STATUSES, 'status'),
+    memory_type: typeof input.memory_type === 'string' ? input.memory_type : undefined,
+    source_platform: typeof input.source_platform === 'string' ? input.source_platform : undefined,
+    sensitivity_level: optionalEnum(input.sensitivity_level, MEMORY_SENSITIVITY_LEVELS, 'sensitivity_level'),
+    user_control: optionalEnum(input.user_control, MEMORY_USER_CONTROLS, 'user_control'),
+    created_after: optionalNumber(input.created_after, 'created_after'),
+    created_before: optionalNumber(input.created_before, 'created_before'),
+    updated_after: optionalNumber(input.updated_after, 'updated_after'),
+    updated_before: optionalNumber(input.updated_before, 'updated_before'),
+    min_confidence: optionalNumber(input.min_confidence, 'min_confidence'),
+    min_importance: optionalNumber(input.min_importance, 'min_importance'),
+    conflict_state: optionalEnum(input.conflict_state, MEMORY_CONFLICT_STATES, 'conflict_state'),
+  }
+}
+
+export function setupMemoryHandlers(): void {
+  ipcMain.handle('memory:get-status', async (): Promise<IpcResponse<{ paused: boolean }>> => {
+    try {
+      const status = await localMemoryControlService.getCaptureStatus()
+      return { success: true, data: status }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  })
+
+  ipcMain.handle(
+    'memory:remember-this',
+    async (_event, input: CreateLocalMemoryInput): Promise<IpcResponse<LocalMemoryItem>> => {
+      try {
+        const memory = await localMemoryControlService.rememberThis(sanitizeCreateMemoryInput(input))
+        return { success: true, data: memory }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:do-not-remember-this',
+    async (_event, input: DoNotRememberInput): Promise<IpcResponse<LocalMemoryItem>> => {
+      try {
+        const memory = await localMemoryControlService.doNotRememberThis(sanitizeDoNotRememberInput(input))
+        return { success: true, data: memory }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle('memory:get', async (_event, id: string): Promise<IpcResponse<LocalMemoryItem | null>> => {
+    try {
+      const memory = await localMemoryControlService.getMemoryById(assertNonEmptyString(id, 'id'))
+      return { success: true, data: memory }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  })
+
+
+  ipcMain.handle(
+    'memory:get-explained',
+    async (_event, id: string): Promise<IpcResponse<ExplainedLocalMemoryItem | null>> => {
+      try {
+        const memory = await localMemoryControlService.getExplainedMemoryById(assertNonEmptyString(id, 'id'))
+        return { success: true, data: memory }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:get-provenance',
+    async (_event, id: string): Promise<IpcResponse<MemoryProvenance | null>> => {
+      try {
+        const provenance = await localMemoryControlService.getMemoryProvenance(assertNonEmptyString(id, 'id'))
+        return { success: true, data: provenance }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:list',
+    async (_event, filters?: LocalMemoryListFilters): Promise<IpcResponse<LocalMemoryItem[]>> => {
+      try {
+        const memories = await localMemoryControlService.listMemories(sanitizeListFilters(filters))
+        return { success: true, data: memories }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+
+  ipcMain.handle(
+    'memory:list-explained',
+    async (_event, filters?: LocalMemoryListFilters): Promise<IpcResponse<ExplainedLocalMemoryItem[]>> => {
+      try {
+        const memories = await localMemoryControlService.listExplainedMemories(sanitizeListFilters(filters))
+        return { success: true, data: memories }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:search',
+    async (_event, filters?: MemorySearchFilters): Promise<IpcResponse<MemoryRetrievalResult[]>> => {
+      try {
+        const results = await localMemoryControlService.searchMemories(sanitizeSearchFilters(filters))
+        return { success: true, data: results }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:update',
+    async (
+      _event,
+      id: string,
+      updates: UpdateLocalMemoryInput
+    ): Promise<IpcResponse<LocalMemoryItem | null>> => {
+      try {
+        const memory = await localMemoryControlService.updateMemory(assertNonEmptyString(id, 'id'), sanitizeUpdateMemoryInput(updates))
+        return { success: true, data: memory }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle('memory:delete', async (_event, id: string): Promise<IpcResponse<{ deleted: boolean }>> => {
+    try {
+      const deleted = await localMemoryControlService.deleteMemory(assertNonEmptyString(id, 'id'))
+      return { success: true, data: { deleted } }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  })
+
+
+  ipcMain.handle(
+    'memory:delete-by-source',
+    async (_event, sourcePlatform: string): Promise<IpcResponse<{ deletedCount: number }>> => {
+      try {
+        const deletedCount = await localMemoryControlService.deleteMemoriesBySource(assertNonEmptyString(sourcePlatform, 'sourcePlatform'))
+        return { success: true, data: { deletedCount } }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:list-events',
+    async (_event, memoryId: string): Promise<IpcResponse<MemoryEventRecord[]>> => {
+      try {
+        const events = await localMemoryControlService.listMemoryEvents(assertNonEmptyString(memoryId, 'memoryId'))
+        return { success: true, data: events }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:pause-capture',
+    async (_event, reason?: string): Promise<IpcResponse<{ paused: boolean }>> => {
+      try {
+        const status = await localMemoryControlService.pauseCapture(reason)
+        return { success: true, data: status }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'memory:resume-capture',
+    async (_event, reason?: string): Promise<IpcResponse<{ paused: boolean }>> => {
+      try {
+        const status = await localMemoryControlService.resumeCapture(reason)
+        return { success: true, data: status }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) }
+      }
+    }
+  )
+
+  console.log('[Memory IPC] Handlers registered')
+}

--- a/src/main/ipc/settings.handlers.ts
+++ b/src/main/ipc/settings.handlers.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises'
 import * as path from 'path'
 import { loadSettings, saveSettings, type AppSettings } from '../config/settings.config'
 import { mcpService } from '../services/mcp.service'
-import { secureStorage } from '../services/secure-storage.service'
+import { secureStorage, createMcpEnvKey, MCP_ENV_PREFIX } from '../services/secure-storage.service'
 import { detectCustomProtocol } from '../services/agent/utils'
 import type { IpcResponse } from '../types'
 
@@ -90,8 +90,8 @@ async function loadUserMcpConfig(): Promise<McpServerConfig> {
       if (serverConfig.env) {
         const decryptedEnv: Record<string, string> = {}
         for (const [envKey, envValue] of Object.entries(serverConfig.env)) {
-          const storageKey = secureStorage.createMcpEnvKey(serverName, envKey)
-          const decrypted = secureStorage.get(storageKey)
+          const storageKey = createMcpEnvKey(serverName, envKey)
+          const decrypted = await secureStorage.get(storageKey)
           if (decrypted !== null) {
             decryptedEnv[envKey] = decrypted
           } else {
@@ -128,9 +128,9 @@ async function saveMcpConfig(config: McpServerConfig): Promise<void> {
     if (rest.env && Object.keys(rest.env).length > 0) {
       const envPlaceholders: Record<string, string> = {}
       for (const [envKey, envValue] of Object.entries(rest.env)) {
-        const storageKey = secureStorage.createMcpEnvKey(name, envKey)
+        const storageKey = createMcpEnvKey(name, envKey)
         // Store actual value in secureStorage
-        secureStorage.set(storageKey, envValue)
+        await secureStorage.set(storageKey, envValue)
         allSecureEnvKeys.add(storageKey)
         // Store placeholder in config file
         envPlaceholders[envKey] = `[SECURE:${storageKey}]`
@@ -153,16 +153,16 @@ async function cleanupSecureMcpEnvKeys(currentConfig: McpServerConfig): Promise<
   for (const [name, serverConfig] of Object.entries(currentConfig)) {
     if (serverConfig.env) {
       for (const envKey of Object.keys(serverConfig.env)) {
-        currentKeys.add(secureStorage.createMcpEnvKey(name, envKey))
+        currentKeys.add(createMcpEnvKey(name, envKey))
       }
     }
   }
 
   // Get all MCP env keys from secureStorage
-  const allSecureStorage = secureStorage.getAll()
+  const allSecureStorage = await secureStorage.getAll()
   for (const key of Object.keys(allSecureStorage)) {
-    if (key.startsWith('mcp:env:') && !currentKeys.has(key)) {
-      secureStorage.delete(key)
+    if (key.startsWith(MCP_ENV_PREFIX) && !currentKeys.has(key)) {
+      await secureStorage.delete(key)
       console.log(`[Settings] Cleaned up orphaned MCP env key: ${key}`)
     }
   }

--- a/src/main/services/agent/__tests__/gemini-adapter.test.ts
+++ b/src/main/services/agent/__tests__/gemini-adapter.test.ts
@@ -56,7 +56,7 @@ describe('convertToolsToGemini', () => {
     ];
 
     const result = convertToolsToGemini(tools);
-    const params = result[0].functionDeclarations![0].parameters as Record<string, unknown>;
+    const params = result[0].functionDeclarations![0].parameters as unknown as Record<string, unknown>;
     expect(params).not.toHaveProperty('$schema');
     expect(params).not.toHaveProperty('additionalProperties');
     expect(params).not.toHaveProperty('type');

--- a/src/main/services/local-memory-control.service.ts
+++ b/src/main/services/local-memory-control.service.ts
@@ -1,0 +1,179 @@
+import { LocalControlledMemoryProvider } from './memory/local-controlled-memory.provider'
+import { memorizationStorage } from './memorization.storage'
+import type {
+  CreateLocalMemoryInput,
+  ExplainedLocalMemoryItem,
+  LocalMemoryItem,
+  LocalMemoryListFilters,
+  MemoryEventRecord,
+  MemoryProvenance,
+  MemoryRetrievalResult,
+  MemorySearchFilters,
+  UpdateLocalMemoryInput,
+  MemorySensitivityLevel,
+} from './memory/local-memory.store'
+
+export interface DoNotRememberInput {
+  content: string
+  memory_type?: string
+  source_platform?: string | null
+  source_excerpt?: string | null
+  sensitivity_level?: MemorySensitivityLevel
+  reason?: string | null
+}
+
+class LocalMemoryControlService {
+  private readonly provider = new LocalControlledMemoryProvider()
+
+  async initialize(): Promise<void> {
+    await this.provider.isConfigured()
+  }
+
+  async getCaptureStatus(): Promise<{ paused: boolean }> {
+    await this.initialize()
+    return this.provider.getCaptureStatus()
+  }
+
+  async rememberThis(input: CreateLocalMemoryInput): Promise<LocalMemoryItem> {
+    await this.initialize()
+    return this.provider.createMemory({
+      ...input,
+      status: input.status ?? 'active',
+      user_control: 'remember',
+      why_stored: input.why_stored ?? 'User explicitly chose to remember this',
+    })
+  }
+
+  async doNotRememberThis(input: DoNotRememberInput): Promise<LocalMemoryItem> {
+    await this.initialize()
+
+    const existingMatches = await this.provider.searchMemories({
+      query: input.content,
+      limit: 10,
+      include_archived: true,
+      source_platform: input.source_platform ?? undefined,
+      exclude_sensitive: false,
+    })
+
+    let existingSuppressionRule: LocalMemoryItem | null = null
+
+    for (const match of existingMatches) {
+      if (match.memory.content !== input.content) {
+        continue
+      }
+
+      if (match.memory.user_control === 'dont_remember') {
+        existingSuppressionRule = match.memory
+        continue
+      }
+
+      await this.provider.updateMemory(match.memory.id, {
+        status: 'archived',
+        user_control: 'dont_remember',
+        why_stored: input.reason ?? 'Archived because the user explicitly chose not to remember this',
+      })
+    }
+
+    if (existingSuppressionRule) {
+      return (
+        (await this.provider.updateMemory(existingSuppressionRule.id, {
+          memory_type: input.memory_type ?? existingSuppressionRule.memory_type ?? 'suppression_rule',
+          source_platform: input.source_platform ?? existingSuppressionRule.source_platform ?? null,
+          source_excerpt: input.source_excerpt ?? input.content.slice(0, 240),
+          sensitivity_level: input.sensitivity_level ?? existingSuppressionRule.sensitivity_level ?? 'normal',
+          status: 'archived',
+          user_control: 'dont_remember',
+          why_stored: input.reason ?? 'User explicitly chose not to remember this',
+          retention_until: null,
+          confidence: 1,
+          importance: 0,
+        })) ?? existingSuppressionRule
+      )
+    }
+
+    return this.provider.createMemory({
+      content: input.content,
+      memory_type: input.memory_type ?? 'suppression_rule',
+      source_platform: input.source_platform ?? null,
+      source_excerpt: input.source_excerpt ?? input.content.slice(0, 240),
+      confidence: 1,
+      importance: 0,
+      sensitivity_level: input.sensitivity_level ?? 'normal',
+      retention_until: null,
+      status: 'archived',
+      user_control: 'dont_remember',
+      why_stored: input.reason ?? 'User explicitly chose not to remember this',
+    })
+  }
+
+  async getMemoryById(id: string): Promise<LocalMemoryItem | null> {
+    await this.initialize()
+    return this.provider.getMemoryById(id)
+  }
+
+
+  async getExplainedMemoryById(id: string): Promise<ExplainedLocalMemoryItem | null> {
+    await this.initialize()
+    return this.provider.getExplainedMemoryById(id)
+  }
+
+  async getMemoryProvenance(id: string): Promise<MemoryProvenance | null> {
+    await this.initialize()
+    return this.provider.getMemoryProvenance(id)
+  }
+
+  async searchMemories(filters: MemorySearchFilters = {}): Promise<MemoryRetrievalResult[]> {
+    await this.initialize()
+    return this.provider.searchMemories(filters)
+  }
+
+  async listExplainedMemories(filters: LocalMemoryListFilters = {}): Promise<ExplainedLocalMemoryItem[]> {
+    await this.initialize()
+    return this.provider.listExplainedMemories(filters)
+  }
+
+  async listMemories(filters: LocalMemoryListFilters = {}): Promise<LocalMemoryItem[]> {
+    await this.initialize()
+    return this.provider.listMemories(filters)
+  }
+
+  async updateMemory(id: string, updates: UpdateLocalMemoryInput): Promise<LocalMemoryItem | null> {
+    await this.initialize()
+    return this.provider.updateMemory(id, {
+      ...updates,
+      user_control: updates.user_control ?? 'modified',
+    })
+  }
+
+  async deleteMemory(id: string): Promise<boolean> {
+    await this.initialize()
+    return this.provider.deleteMemory(id)
+  }
+
+  async deleteMemoriesBySource(sourcePlatform: string): Promise<number> {
+    await this.initialize()
+    return this.provider.deleteMemoriesBySource(sourcePlatform)
+  }
+
+  async listMemoryEvents(memoryId: string): Promise<MemoryEventRecord[]> {
+    await this.initialize()
+    return this.provider.listMemoryEvents(memoryId)
+  }
+
+  async pauseCapture(reason?: string): Promise<{ paused: boolean }> {
+    await this.initialize()
+    const result = await this.provider.pauseCapture(reason)
+    await memorizationStorage.initialize()
+    await memorizationStorage.clearMessages()
+    await memorizationStorage.clearTaskState()
+    await memorizationStorage.updateFirstMessageTimestamp()
+    return result
+  }
+
+  async resumeCapture(reason?: string): Promise<{ paused: boolean }> {
+    await this.initialize()
+    return this.provider.resumeCapture(reason)
+  }
+}
+
+export const localMemoryControlService = new LocalMemoryControlService()

--- a/src/main/services/memorization.service.ts
+++ b/src/main/services/memorization.service.ts
@@ -1,13 +1,13 @@
-import { loadSettings } from '../config/settings.config'
 import {
   infraService,
   type IncomingMessageEvent,
   type OutgoingMessageEvent,
 } from './infra.service'
-import {
-  memorizationStorage,
-  type StoredUnmemorizedMessage,
-} from './memorization.storage'
+import { memorizationStorage, type StoredUnmemorizedMessage } from './memorization.storage'
+import { loadSettings } from '../config/settings.config'
+import type { MemoryProvider } from './memory/memory-provider'
+import { RemoteMemuProvider } from './memory/remote-memu.provider'
+import { LocalControlledMemoryProvider } from './memory/local-controlled-memory.provider'
 
 const CHAT_MEMORIZE_MESSAGE_THRESHOLD = 20
 const CHAT_MEMORIZE_TIME_THRESHOLD_MS = 60 * 60 * 1000 // 60 minutes
@@ -15,58 +15,42 @@ const CHAT_MEMORIZE_TIME_THRESHOLD_MS = 60 * 60 * 1000 // 60 minutes
 const MEMORIZE_MIN_MESSAGE_COUNT = 2
 const MEMORIZE_MAX_MESSAGE_COUNT = 200
 
-const MEMORIZE_STATUS_POLL_INTERVAL_MS = 10_000
-const MEMORIZE_MAX_WAIT_MS = 5 * 60 * 1000
-
-type MemorizeStatus = 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'FAILURE'
-
-interface MemorizeStatusResponse {
-  task_id: string
-  status: MemorizeStatus
-  detail_info: string
-}
-
 class MemorizationService {
   private unsubscribers: (() => void)[] = []
   private isMemorizing = false
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly remoteMemoryProvider = new RemoteMemuProvider()
+  private readonly localMemoryProvider = new LocalControlledMemoryProvider()
 
-  // ==================== Config ====================
-
-  private async getMemuConfig() {
+  private async getMemoryProvider(): Promise<MemoryProvider> {
     const settings = await loadSettings()
-    return {
-      baseUrl: settings.memuBaseUrl,
-      apiKey: settings.memuApiKey,
-      userId: settings.memuUserId,
-      agentId: settings.memuAgentId,
-    }
+    const hasRemoteConfiguration = !!(
+      settings.memuApiKey && settings.memuApiKey.trim() &&
+      settings.memuBaseUrl && settings.memuBaseUrl.trim() &&
+      settings.memuUserId && settings.memuUserId.trim() &&
+      settings.memuAgentId && settings.memuAgentId.trim()
+    )
+    return hasRemoteConfiguration ? this.remoteMemoryProvider : this.localMemoryProvider
   }
 
   // ==================== Lifecycle ====================
 
-  private async isApiKeyConfigured(): Promise<boolean> {
-    const settings = await loadSettings()
-    return !!(settings.memuApiKey && settings.memuApiKey.trim())
-  }
-
   async start(): Promise<boolean> {
     await memorizationStorage.initialize()
 
-    const hasKey = await this.isApiKeyConfigured()
-    if (!hasKey) {
-      console.log('[Memorization] memuApiKey not configured, messages will be queued locally until key is set')
+    const provider = await this.getMemoryProvider()
+    const isRemote = provider.kind === 'remote-memu'
+
+    if (!isRemote) {
+      console.log('[Memorization] Remote memU not configured, using local controlled memory provider')
     }
 
-    // Recover from previous run (only if API key is available)
-    if (hasKey) {
-      await this.recoverPendingTask()
+    if (isRemote && (await provider.isConfigured())) {
+      await this.recoverPendingTask(provider)
     }
 
-    // Check if memorization conditions are already met from persisted messages
     await this.checkAndTrigger()
 
-    // Subscribe to both incoming and outgoing messages
     this.unsubscribers.push(
       infraService.subscribe('message:incoming', (event) => {
         this.handleMessage(event, 'incoming')
@@ -89,13 +73,23 @@ class MemorizationService {
     console.log('[Memorization] Service stopped')
   }
 
-  // ==================== Message handling ====================
-
   private handleMessage(
     event: IncomingMessageEvent | OutgoingMessageEvent,
     _direction: 'incoming' | 'outgoing'
   ): void {
+    void this.handleMessageAsync(event)
+  }
+
+  private async handleMessageAsync(event: IncomingMessageEvent | OutgoingMessageEvent): Promise<void> {
     if (event.platform === 'none') return
+
+    const provider = await this.getMemoryProvider()
+    if (provider.kind === 'local-controlled-memory') {
+      const localStatus = await this.localMemoryProvider.getCaptureStatus()
+      if (localStatus.paused) {
+        return
+      }
+    }
 
     const content =
       typeof event.message.content === 'string'
@@ -109,20 +103,18 @@ class MemorizationService {
       timestamp: event.timestamp,
     }
 
-    memorizationStorage.appendMessage(stored).then(() => {
-      console.log(
-        `[Memorization] Queued message from ${event.platform} (queue size: ~${stored.timestamp})`
-      )
-      this.checkAndTrigger()
-    })
+    await memorizationStorage.appendMessage(stored)
+    console.log(
+      `[Memorization] Queued message from ${event.platform} (queue size: ~${stored.timestamp})`
+    )
+    await this.checkAndTrigger()
   }
 
-  // ==================== Trigger logic ====================
-
   private async checkAndTrigger(): Promise<void> {
-    // If a task is in-flight, do a single status check instead of blocking
+    const provider = await this.getMemoryProvider()
+
     if (this.isMemorizing) {
-      await this.checkActiveTask()
+      await this.checkActiveTask(provider)
       if (this.isMemorizing) return
     }
 
@@ -138,7 +130,6 @@ class MemorizationService {
       return
     }
 
-    // Count below threshold — use debounce timer
     if (count >= MEMORIZE_MIN_MESSAGE_COUNT) {
       this.resetDebounceTimer()
     }
@@ -160,70 +151,35 @@ class MemorizationService {
     }
   }
 
-  // ==================== Task status helpers ====================
-
-  /**
-   * Fetch the status of a memorization task and handle storage cleanup
-   * on terminal states (SUCCESS / FAILURE).
-   *
-   * Returns:
-   *  - 'success'  — task completed, queued messages removed from storage
-   *  - 'failure'  — task failed, task state cleared
-   *  - 'pending'  — task still PENDING or PROCESSING
-   *  - 'error'    — network / parse error (nothing changed)
-   */
   private async resolveTaskStatus(
+    provider: MemoryProvider,
     taskId: string,
     messageCount: number
   ): Promise<'success' | 'failure' | 'pending' | 'error'> {
     try {
-      const memuConfig = await this.getMemuConfig()
-      const response = await fetch(
-        `${memuConfig.baseUrl}/api/v3/memory/memorize/status/${taskId}`,
-        {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${memuConfig.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      )
-
-      if (!response.ok) {
-        console.error(`[Memorization] Status check failed for ${taskId}: ${response.status}`)
-        return 'error'
-      }
-
-      const result = (await response.json()) as MemorizeStatusResponse
-      console.log(`[Memorization] Task ${taskId} status: ${result.status}`)
-
-      if (result.status === 'SUCCESS') {
-        await memorizationStorage.removeFirstN(messageCount)
-        await memorizationStorage.clearTaskState()
-        await memorizationStorage.updateFirstMessageTimestamp()
-        return 'success'
-      }
-
-      if (result.status === 'FAILURE') {
-        console.error(`[Memorization] Task ${taskId} failed: ${result.detail_info}`)
-        await memorizationStorage.clearTaskState()
-        return 'failure'
-      }
-
-      return 'pending'
+      const result = await provider.checkTaskStatus(taskId, messageCount)
+      return result.status
     } catch (error) {
       console.error(`[Memorization] Error checking task ${taskId}:`, error)
       return 'error'
     }
   }
 
-  /**
-   * Single non-blocking status check for the current in-flight task.
-   * Called lazily from checkAndTrigger so we only hit the server when a
-   * new message arrives or the debounce timer fires.
-   */
-  private async checkActiveTask(): Promise<void> {
-    if (!(await this.isApiKeyConfigured())) return
+  private async finalizeResolvedTask(
+    outcome: 'success' | 'failure' | 'error',
+    messageCount: number
+  ): Promise<void> {
+    if (outcome === 'success' && messageCount > 0) {
+      await memorizationStorage.removeFirstN(messageCount)
+      await memorizationStorage.updateFirstMessageTimestamp()
+    }
+
+    await memorizationStorage.clearTaskState()
+    this.isMemorizing = false
+  }
+
+  private async checkActiveTask(provider: MemoryProvider): Promise<void> {
+    if (!(await provider.isConfigured())) return
 
     const state = await memorizationStorage.getState()
     if (!state.lastTaskId) {
@@ -232,17 +188,15 @@ class MemorizationService {
     }
 
     const outcome = await this.resolveTaskStatus(
+      provider,
       state.lastTaskId,
       state.messagesToRemoveOnSuccess
     )
 
-    if (outcome === 'success' || outcome === 'failure') {
-      this.isMemorizing = false
+    if (outcome === 'success' || outcome === 'failure' || outcome === 'error') {
+      await this.finalizeResolvedTask(outcome, state.messagesToRemoveOnSuccess)
     }
-    // 'pending' / 'error' — keep isMemorizing true, will retry on next call
   }
-
-  // ==================== Memorization execution ====================
 
   private triggerMemorization(): void {
     if (this.isMemorizing) return
@@ -255,73 +209,42 @@ class MemorizationService {
 
   private async runMemorization(): Promise<void> {
     try {
-      if (!(await this.isApiKeyConfigured())) {
-        console.log('[Memorization] memuApiKey not configured, skipping memorize POST (messages remain queued)')
+      const provider = await this.getMemoryProvider()
+      if (!(await provider.isConfigured())) {
+        console.log('[Memorization] No available memory provider configured')
         this.isMemorizing = false
         return
       }
 
-      const memuConfig = await this.getMemuConfig()
       const allMessages = await memorizationStorage.getMessages()
 
       if (allMessages.length < MEMORIZE_MIN_MESSAGE_COUNT) {
-        console.log('[Memorization] Not enough messages to memorize, skipping memorize POST (messages remain queued)')
+        console.log('[Memorization] Not enough messages to memorize')
         this.isMemorizing = false
         return
       }
 
       const messages = allMessages.slice(0, MEMORIZE_MAX_MESSAGE_COUNT)
-      const messageCount = messages.length
-
-      const formattedMessages = messages.map((m) => ({
-        role: m.role,
-        content: `[${m.platform}] ${m.content}`,
-      }))
-
-      console.log(
-        `[Memorization] Sending ${formattedMessages.length} messages to memorize`
-      )
-
-      const response = await fetch(
-        `${memuConfig.baseUrl}/api/v3/memory/memorize`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${memuConfig.apiKey}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            user_id: memuConfig.userId,
-            agent_id: memuConfig.agentId,
-            conversation: formattedMessages,
-          }),
-        }
-      )
-
-      if (!response.ok) {
-        console.error(
-          '[Memorization] API returned status:',
-          response.status
-        )
-        this.isMemorizing = false
-        return
-      }
-
-      const result = (await response.json()) as { task_id?: string }
-      const taskId = result.task_id
+      const { taskId, messageCount } = await provider.startMemorization(messages)
 
       if (!taskId) {
-        console.error('[Memorization] No task_id returned')
+        if (provider.kind === 'local-controlled-memory' && messageCount > 0) {
+          await memorizationStorage.removeFirstN(messageCount)
+          await memorizationStorage.clearTaskState()
+          await memorizationStorage.updateFirstMessageTimestamp()
+        } else if (provider.kind === 'remote-memu') {
+          console.warn('[Memorization] Remote memorization did not start; falling back to local controlled memory')
+          const fallbackResult = await this.localMemoryProvider.startMemorization(messages)
+          if (fallbackResult.messageCount > 0) {
+            await memorizationStorage.removeFirstN(fallbackResult.messageCount)
+            await memorizationStorage.updateFirstMessageTimestamp()
+          }
+          await memorizationStorage.clearTaskState()
+        }
         this.isMemorizing = false
         return
       }
 
-      console.log(`[Memorization] Task started: ${taskId}`)
-
-      // Persist so we can recover if the process restarts.
-      // Status will be checked lazily in checkActiveTask on the next
-      // checkAndTrigger call (i.e. when a new message arrives or the
-      // debounce timer fires).
       await memorizationStorage.setState({
         lastTaskId: taskId,
         messagesToRemoveOnSuccess: messageCount,
@@ -332,40 +255,8 @@ class MemorizationService {
     }
   }
 
-  private async monitorTask(
-    taskId: string,
-    messageCount: number
-  ): Promise<void> {
-    const startTime = Date.now()
-
-    while (Date.now() - startTime < MEMORIZE_MAX_WAIT_MS) {
-      const outcome = await this.resolveTaskStatus(taskId, messageCount)
-
-      if (outcome === 'success') {
-        console.log('[Memorization] Memorization succeeded')
-        this.isMemorizing = false
-        await this.checkAndTrigger()
-        return
-      }
-
-      if (outcome === 'failure') {
-        this.isMemorizing = false
-        return
-      }
-
-      // 'pending' or 'error' — wait and retry
-      await this.sleep(MEMORIZE_STATUS_POLL_INTERVAL_MS)
-    }
-
-    console.error(`[Memorization] Task ${taskId} timed out`)
-    await memorizationStorage.clearTaskState()
-    this.isMemorizing = false
-  }
-
-  // ==================== Recovery ====================
-
-  private async recoverPendingTask(): Promise<void> {
-    if (!(await this.isApiKeyConfigured())) return
+  private async recoverPendingTask(provider: MemoryProvider): Promise<void> {
+    if (!(await provider.isConfigured())) return
 
     const state = await memorizationStorage.getState()
     if (!state.lastTaskId) return
@@ -377,30 +268,17 @@ class MemorizationService {
     this.isMemorizing = true
 
     const outcome = await this.resolveTaskStatus(
+      provider,
       state.lastTaskId,
       state.messagesToRemoveOnSuccess
     )
 
-    if (outcome === 'success' || outcome === 'failure') {
-      this.isMemorizing = false
+    if (outcome === 'success' || outcome === 'failure' || outcome === 'error') {
+      await this.finalizeResolvedTask(outcome, state.messagesToRemoveOnSuccess)
       return
     }
 
-    if (outcome === 'error') {
-      await memorizationStorage.clearTaskState()
-      this.isMemorizing = false
-      return
-    }
-
-    // 'pending' — leave isMemorizing true;
-    // checkActiveTask will resolve it lazily on the next checkAndTrigger call
     console.log('[Memorization] Recovered task still pending, will check again lazily')
-  }
-
-  // ==================== Helpers ====================
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms))
   }
 }
 

--- a/src/main/services/memorization.storage.ts
+++ b/src/main/services/memorization.storage.ts
@@ -98,6 +98,13 @@ class MemorizationStorage {
     console.log(`[MemorizationStorage] Removed first ${count} messages, ${this.messages.length} remaining`)
   }
 
+
+  async clearMessages(): Promise<void> {
+    await this.ensureInitialized()
+    this.messages = []
+    await this.saveMessages()
+  }
+
   // ==================== State ====================
 
   private async loadState(): Promise<void> {

--- a/src/main/services/memory/local-controlled-memory.provider.ts
+++ b/src/main/services/memory/local-controlled-memory.provider.ts
@@ -1,0 +1,235 @@
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { app } from 'electron'
+import type { StoredUnmemorizedMessage } from '../memorization.storage'
+import {
+  localMemoryStore,
+  type CreateLocalMemoryInput,
+  type ExplainedLocalMemoryItem,
+  type LocalMemoryItem,
+  type LocalMemoryListFilters,
+  type MemoryEventRecord,
+  type MemoryProvenance,
+  type MemoryRetrievalResult,
+  type MemorySearchFilters,
+  type UpdateLocalMemoryInput,
+} from './local-memory.store'
+import type { MemoryProvider, MemoryProviderResult } from './memory-provider'
+
+const STORAGE_DIR = 'memorization-data'
+const PROVIDER_STATE_FILE = 'local-memory-provider-state.json'
+
+interface LocalMemoryProviderState {
+  capturePaused: boolean
+  updatedAt: number
+  reason?: string | null
+}
+
+const DEFAULT_PROVIDER_STATE: LocalMemoryProviderState = {
+  capturePaused: false,
+  updatedAt: 0,
+  reason: null,
+}
+
+export class LocalControlledMemoryProvider implements MemoryProvider {
+  readonly kind = 'local-controlled-memory'
+  private statePath = path.join(app.getPath('userData'), STORAGE_DIR, PROVIDER_STATE_FILE)
+  private state: LocalMemoryProviderState = { ...DEFAULT_PROVIDER_STATE }
+  private stateLoaded = false
+
+  async isConfigured(): Promise<boolean> {
+    await localMemoryStore.initialize()
+    await this.ensureStateLoaded()
+    return true
+  }
+
+  async startMemorization(messages: StoredUnmemorizedMessage[]): Promise<{
+    taskId: string | null
+    messageCount: number
+  }> {
+    await localMemoryStore.initialize()
+    await this.ensureStateLoaded()
+
+    if (this.state.capturePaused) {
+      return {
+        taskId: null,
+        messageCount: 0,
+      }
+    }
+
+    let storedCount = 0
+
+    for (const message of messages) {
+      if (await localMemoryStore.hasSuppressedMatch(message.content, message.platform)) {
+        continue
+      }
+
+      const inferredSensitivity = this.inferAutomaticSensitivity(message.content, message.platform)
+      if (inferredSensitivity === 'sensitive') {
+        continue
+      }
+
+      const existing = await localMemoryStore.searchMemories({
+        query: message.content,
+        limit: 1,
+        source_platform: message.platform,
+        memory_type: 'conversation_message',
+        include_archived: true,
+        exclude_sensitive: false,
+      })
+
+      const best = existing[0]
+      const looksDuplicated = best && best.memory.content === message.content && best.retrieval_explanation.score >= 4.5
+      if (looksDuplicated) {
+        continue
+      }
+
+      await this.createMemory({
+        content: message.content,
+        memory_type: 'conversation_message',
+        source_platform: message.platform,
+        source_excerpt: message.content.slice(0, 240),
+        confidence: inferredSensitivity === 'work' ? 0.6 : 0.5,
+        importance: inferredSensitivity === 'work' ? 0.65 : 0.5,
+        sensitivity_level: inferredSensitivity,
+        status: 'active',
+        user_control: 'auto',
+        why_stored: 'Captured from message stream by LocalControlledMemoryProvider',
+      })
+      storedCount += 1
+    }
+
+    return {
+      taskId: null,
+      messageCount: storedCount,
+    }
+  }
+
+
+  private inferAutomaticSensitivity(content: string, sourcePlatform?: string | null): 'normal' | 'work' | 'sensitive' {
+    const text = `${sourcePlatform ?? ''} ${content}`.toLowerCase()
+    if (/password|passcode|otp|verification code|ssn|social security|bank account|credit card|api key|secret|token|passport|diagnosis|medical/.test(text)) {
+      return 'sensitive'
+    }
+    if (/slack|meeting|project|roadmap|deadline|client|customer|jira|notion|github|repo|work/.test(text)) {
+      return 'work'
+    }
+    return 'normal'
+  }
+
+  async checkTaskStatus(_taskId: string, _messageCount: number): Promise<MemoryProviderResult> {
+    return { status: 'success' }
+  }
+
+  async createMemory(input: CreateLocalMemoryInput): Promise<LocalMemoryItem> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.createMemory(input)
+  }
+
+  async getMemoryById(id: string): Promise<LocalMemoryItem | null> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.getMemoryById(id)
+  }
+
+
+  async getExplainedMemoryById(id: string): Promise<ExplainedLocalMemoryItem | null> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.getExplainedMemoryById(id)
+  }
+
+  async getMemoryProvenance(id: string): Promise<MemoryProvenance | null> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.getProvenanceById(id)
+  }
+
+  async searchMemories(filters: MemorySearchFilters = {}): Promise<MemoryRetrievalResult[]> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.searchMemories(filters)
+  }
+
+  async listExplainedMemories(filters: LocalMemoryListFilters = {}): Promise<ExplainedLocalMemoryItem[]> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.listExplainedMemories(filters)
+  }
+
+  async listMemories(filters: LocalMemoryListFilters = {}): Promise<LocalMemoryItem[]> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.listMemories(filters)
+  }
+
+  async updateMemory(id: string, updates: UpdateLocalMemoryInput): Promise<LocalMemoryItem | null> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.updateMemory(id, updates)
+  }
+
+  async deleteMemory(id: string): Promise<boolean> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.deleteMemory(id)
+  }
+
+  async deleteMemoriesBySource(sourcePlatform: string): Promise<number> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.deleteMemoriesBySource(sourcePlatform)
+  }
+
+  async listMemoryEvents(memoryId: string): Promise<MemoryEventRecord[]> {
+    await localMemoryStore.initialize()
+    return localMemoryStore.listEvents(memoryId)
+  }
+
+  async getCaptureStatus(): Promise<{ paused: boolean }> {
+    await this.ensureStateLoaded()
+    return { paused: this.state.capturePaused }
+  }
+
+  async pauseCapture(reason?: string): Promise<{ paused: boolean }> {
+    await this.ensureStateLoaded()
+    if (!this.state.capturePaused) {
+      this.state = {
+        capturePaused: true,
+        updatedAt: Date.now(),
+        reason: reason ?? null,
+      }
+      await this.saveState()
+    }
+    return { paused: true }
+  }
+
+  async resumeCapture(reason?: string): Promise<{ paused: boolean }> {
+    await this.ensureStateLoaded()
+    if (this.state.capturePaused) {
+      this.state = {
+        capturePaused: false,
+        updatedAt: Date.now(),
+        reason: reason ?? null,
+      }
+      await this.saveState()
+    }
+    return { paused: false }
+  }
+
+  private async ensureStateLoaded(): Promise<void> {
+    if (this.stateLoaded) return
+
+    try {
+      await fs.mkdir(path.dirname(this.statePath), { recursive: true })
+      const raw = await fs.readFile(this.statePath, 'utf-8')
+      const parsed = JSON.parse(raw) as Partial<LocalMemoryProviderState>
+      this.state = {
+        capturePaused: parsed.capturePaused ?? DEFAULT_PROVIDER_STATE.capturePaused,
+        updatedAt: parsed.updatedAt ?? DEFAULT_PROVIDER_STATE.updatedAt,
+        reason: parsed.reason ?? DEFAULT_PROVIDER_STATE.reason,
+      }
+    } catch {
+      this.state = { ...DEFAULT_PROVIDER_STATE }
+      await this.saveState()
+    }
+
+    this.stateLoaded = true
+  }
+
+  private async saveState(): Promise<void> {
+    await fs.mkdir(path.dirname(this.statePath), { recursive: true })
+    await fs.writeFile(this.statePath, JSON.stringify(this.state, null, 2), 'utf-8')
+  }
+}

--- a/src/main/services/memory/local-memory.store.ts
+++ b/src/main/services/memory/local-memory.store.ts
@@ -1,0 +1,1015 @@
+import * as fs from 'fs/promises'
+import * as path from 'path'
+import { app } from 'electron'
+
+const STORAGE_DIR = 'memorization-data'
+const DB_FILE = 'local-controlled-memory.sqlite'
+const TIME_DECAY_HALF_LIFE_DAYS = 30
+
+const { DatabaseSync } = require('node:sqlite') as {
+  DatabaseSync: new (path: string) => {
+    exec(sql: string): void
+    prepare(sql: string): {
+      run(params?: Record<string, unknown> | unknown[]): { changes?: number; lastInsertRowid?: number | bigint }
+      get<T = unknown>(params?: Record<string, unknown> | unknown[]): T | undefined
+      all<T = unknown>(params?: Record<string, unknown> | unknown[]): T[]
+    }
+    close(): void
+  }
+}
+
+export type MemoryStatus = 'active' | 'archived' | 'deleted'
+export type MemoryUserControl = 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+export type MemorySensitivityLevel = 'normal' | 'work' | 'sensitive'
+export type MemoryConflictState = 'none' | 'potential' | 'confirmed'
+
+export interface LocalMemoryItem {
+  id: string
+  content: string
+  memory_type: string
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  confidence: number
+  importance: number
+  sensitivity_level: MemorySensitivityLevel
+  retention_until: number | null
+  status: MemoryStatus
+  user_control: MemoryUserControl
+  why_stored: string | null
+  conflict_state: MemoryConflictState
+  conflict_notes: string | null
+}
+
+export interface MemoryProvenance {
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  retention_until: number | null
+  why_stored: string | null
+  sensitivity_level: MemorySensitivityLevel
+  conflict_state: MemoryConflictState
+  conflict_notes: string | null
+}
+
+export interface MemoryExplanation {
+  provenance: MemoryProvenance
+}
+
+export interface ExplainedLocalMemoryItem extends LocalMemoryItem {
+  explanation: MemoryExplanation
+}
+
+export interface MemoryMatchField {
+  field: 'content' | 'memory_type' | 'source_platform' | 'source_excerpt' | 'why_stored' | 'status' | 'user_control' | 'sensitivity_level' | 'conflict_notes'
+  value_excerpt: string
+  matched_terms: string[]
+  score_contribution: number
+  reason: string
+}
+
+export interface MemoryRetrievalExplanation {
+  query: string
+  matched_fields: MemoryMatchField[]
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  retention_until: number | null
+  score: number
+  score_reasons: string[]
+}
+
+export interface MemoryRetrievalResult {
+  memory: ExplainedLocalMemoryItem
+  retrieval_explanation: MemoryRetrievalExplanation
+}
+
+export interface MemorySearchFilters extends LocalMemoryListFilters {
+  query?: string
+  limit?: number
+  include_archived?: boolean
+  created_after?: number
+  created_before?: number
+  updated_after?: number
+  updated_before?: number
+  min_confidence?: number
+  min_importance?: number
+  exclude_sensitive?: boolean
+}
+
+export interface CreateLocalMemoryInput {
+  id?: string
+  content: string
+  memory_type: string
+  source_platform?: string | null
+  source_excerpt?: string | null
+  confidence?: number
+  importance?: number
+  sensitivity_level?: MemorySensitivityLevel
+  retention_until?: number | null
+  status?: MemoryStatus
+  user_control?: MemoryUserControl
+  why_stored?: string | null
+  conflict_state?: MemoryConflictState
+  conflict_notes?: string | null
+}
+
+export interface UpdateLocalMemoryInput {
+  content?: string
+  memory_type?: string
+  source_platform?: string | null
+  source_excerpt?: string | null
+  confidence?: number
+  importance?: number
+  sensitivity_level?: MemorySensitivityLevel
+  retention_until?: number | null
+  status?: MemoryStatus
+  user_control?: MemoryUserControl
+  why_stored?: string | null
+  conflict_state?: MemoryConflictState
+  conflict_notes?: string | null
+}
+
+export interface MemoryEventRecord {
+  id: number
+  memory_id: string
+  event_type: string
+  actor: string
+  previous_status: string | null
+  new_status: string | null
+  reason: string | null
+  payload_json: string | null
+  created_at: number
+}
+
+export interface CreateMemoryEventInput {
+  memory_id: string
+  event_type: string
+  actor?: string
+  previous_status?: string | null
+  new_status?: string | null
+  reason?: string | null
+  payload_json?: string | null
+  created_at?: number
+}
+
+export interface LocalMemoryListFilters {
+  status?: MemoryStatus
+  memory_type?: string
+  source_platform?: string
+  sensitivity_level?: MemorySensitivityLevel
+  user_control?: MemoryUserControl
+  created_after?: number
+  created_before?: number
+  updated_after?: number
+  updated_before?: number
+  min_confidence?: number
+  min_importance?: number
+  conflict_state?: MemoryConflictState
+}
+
+interface ParsedFactSignature {
+  subject: string
+  relation: string
+  value: string
+}
+
+function generateMemoryId(): string {
+  return `mem_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+function clampScore(value: number | undefined, fallback: number): number {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return Math.max(0, Math.min(1, numeric))
+}
+
+function hasOwnProperty<T extends object>(value: T, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function excerptText(value: string | null | undefined, maxLength = 180): string {
+  if (!value) return ''
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value
+}
+
+function tokenizeQuery(query: string): string[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return []
+  return Array.from(new Set(normalized.split(/\s+/).map((term) => term.trim()).filter((term) => term.length > 0)))
+}
+
+function countMatchedTerms(value: string, terms: string[]): string[] {
+  const haystack = value.toLowerCase()
+  return terms.filter((term) => haystack.includes(term))
+}
+
+function buildValueExcerpt(value: string, matchedTerms: string[]): string {
+  if (!value) return ''
+  if (matchedTerms.length === 0) return excerptText(value)
+
+  const lower = value.toLowerCase()
+  const positions = matchedTerms
+    .map((term) => lower.indexOf(term))
+    .filter((pos) => pos >= 0)
+    .sort((a, b) => a - b)
+
+  if (positions.length === 0) return excerptText(value)
+
+  const start = Math.max(0, positions[0] - 40)
+  const end = Math.min(value.length, positions[0] + 140)
+  const snippet = value.slice(start, end)
+
+  return `${start > 0 ? '…' : ''}${snippet}${end < value.length ? '…' : ''}`
+}
+
+function normalizeComparableText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function tokenizeComparableText(value: string): string[] {
+  return normalizeComparableText(value)
+    .split(/[^a-z0-9]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3)
+}
+
+function computeJaccardSimilarity(left: string, right: string): number {
+  const leftTokens = new Set(tokenizeComparableText(left))
+  const rightTokens = new Set(tokenizeComparableText(right))
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0
+
+  let intersection = 0
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) intersection += 1
+  }
+
+  const union = new Set([...leftTokens, ...rightTokens]).size
+  return union === 0 ? 0 : intersection / union
+}
+
+function parseFactSignature(content: string): ParsedFactSignature | null {
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  const match = normalized.match(/^(.+?)\s+(is|are|was|were|lives in|located in|works at|prefers|likes|dislikes|email is|phone is)\s+(.+)$/i)
+  if (!match) return null
+
+  const [, subjectRaw, relationRaw, valueRaw] = match
+  const subject = normalizeComparableText(subjectRaw)
+  const relation = normalizeComparableText(relationRaw)
+  const value = normalizeComparableText(valueRaw)
+
+  if (!subject || !relation || !value) return null
+  return { subject, relation, value }
+}
+
+function inferSensitivityLevel(content: string, sourcePlatform: string | null | undefined, explicit?: MemorySensitivityLevel): MemorySensitivityLevel {
+  if (explicit) return explicit
+  const text = `${sourcePlatform ?? ''} ${content}`.toLowerCase()
+  const sensitivePatterns = [
+    /password|passcode|otp|verification code|ssn|social security|bank account|routing number|credit card|debit card/,
+    /medical|diagnosis|prescription|patient|insurance id|passport|driver'?s license/,
+    /private key|secret|token|api key|auth code/
+  ]
+  if (sensitivePatterns.some((pattern) => pattern.test(text))) return 'sensitive'
+
+  const workPatterns = [/slack|meeting|project|roadmap|deadline|client|customer|jira|notion|github|repo|work/]
+  if (workPatterns.some((pattern) => pattern.test(text))) return 'work'
+
+  return 'normal'
+}
+
+function defaultRetentionUntil(sensitivity: MemorySensitivityLevel, explicit?: number | null): number | null {
+  if (explicit !== undefined) return explicit
+  const now = Date.now()
+  switch (sensitivity) {
+    case 'sensitive':
+      return now + 30 * 24 * 60 * 60 * 1000
+    case 'work':
+      return now + 180 * 24 * 60 * 60 * 1000
+    default:
+      return null
+  }
+}
+
+function buildProvenance(memory: LocalMemoryItem): MemoryProvenance {
+  return {
+    source_platform: memory.source_platform,
+    source_excerpt: memory.source_excerpt,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
+    retention_until: memory.retention_until,
+    why_stored: memory.why_stored,
+    sensitivity_level: memory.sensitivity_level,
+    conflict_state: memory.conflict_state,
+    conflict_notes: memory.conflict_notes,
+  }
+}
+
+function attachExplanation(memory: LocalMemoryItem): ExplainedLocalMemoryItem {
+  return {
+    ...memory,
+    explanation: {
+      provenance: buildProvenance(memory),
+    },
+  }
+}
+
+function computeTimeDecayMultiplier(updatedAt: number, now: number): number {
+  const ageMs = Math.max(0, now - updatedAt)
+  const ageDays = ageMs / (24 * 60 * 60 * 1000)
+  return Math.pow(0.5, ageDays / TIME_DECAY_HALF_LIFE_DAYS)
+}
+
+function scoreMemoryMatch(memory: LocalMemoryItem, query: string, now = Date.now()): MemoryRetrievalResult | null {
+  const terms = tokenizeQuery(query)
+  if (terms.length === 0) return null
+
+  const fieldWeights: Array<{
+    field: MemoryMatchField['field']
+    value: string
+    weight: number
+    reason: string
+  }> = [
+    { field: 'content', value: memory.content, weight: 5, reason: 'Matched memory content' },
+    { field: 'source_excerpt', value: memory.source_excerpt ?? '', weight: 4, reason: 'Matched source excerpt' },
+    { field: 'why_stored', value: memory.why_stored ?? '', weight: 3, reason: 'Matched why this memory was stored' },
+    { field: 'memory_type', value: memory.memory_type, weight: 2, reason: 'Matched memory type' },
+    { field: 'source_platform', value: memory.source_platform ?? '', weight: 1.5, reason: 'Matched source platform' },
+    { field: 'status', value: memory.status, weight: 1, reason: 'Matched status' },
+    { field: 'user_control', value: memory.user_control, weight: 1, reason: 'Matched user control state' },
+    { field: 'sensitivity_level', value: memory.sensitivity_level, weight: 1, reason: 'Matched sensitivity level' },
+    { field: 'conflict_notes', value: memory.conflict_notes ?? '', weight: 0.75, reason: 'Matched conflict notes' },
+  ]
+
+  const matched_fields: MemoryMatchField[] = []
+  let rawScore = 0
+  const score_reasons: string[] = []
+
+  for (const field of fieldWeights) {
+    const matchedTerms = countMatchedTerms(field.value, terms)
+    if (matchedTerms.length === 0) continue
+
+    const contribution = matchedTerms.length * field.weight
+    rawScore += contribution
+    matched_fields.push({
+      field: field.field,
+      value_excerpt: buildValueExcerpt(field.value, matchedTerms),
+      matched_terms: matchedTerms,
+      score_contribution: contribution,
+      reason: field.reason,
+    })
+    score_reasons.push(`${field.reason}: ${matchedTerms.join(', ')}`)
+  }
+
+  if (matched_fields.length === 0) return null
+
+  const confidenceBonus = Math.round(memory.confidence * 100) / 100
+  const importanceBonus = Math.round(memory.importance * 100) / 100
+  rawScore += confidenceBonus + importanceBonus
+  score_reasons.push(`Confidence bonus: ${confidenceBonus.toFixed(2)}`)
+  score_reasons.push(`Importance bonus: ${importanceBonus.toFixed(2)}`)
+
+  const decayMultiplier = computeTimeDecayMultiplier(memory.updated_at, now)
+  rawScore *= decayMultiplier
+  score_reasons.push(`Time decay multiplier: ${decayMultiplier.toFixed(3)}`)
+
+  if (memory.user_control === 'remember') {
+    rawScore += 1
+    score_reasons.push('User explicitly marked this to remember')
+  }
+  if (memory.user_control === 'dont_remember') {
+    rawScore -= 3
+    score_reasons.push('User explicitly marked this as do not remember')
+  }
+  if (memory.status === 'archived') {
+    rawScore -= 1
+    score_reasons.push('Archived memories are de-prioritized')
+  }
+  if (memory.conflict_state === 'potential') {
+    rawScore -= 0.75
+    score_reasons.push('Potentially conflicting memory is de-prioritized')
+  }
+  if (memory.conflict_state === 'confirmed') {
+    rawScore -= 1.5
+    score_reasons.push('Confirmed conflicting memory is strongly de-prioritized')
+  }
+
+  const score = Math.max(0, Number(rawScore.toFixed(3)))
+
+  return {
+    memory: attachExplanation(memory),
+    retrieval_explanation: {
+      query,
+      matched_fields,
+      source_excerpt: memory.source_excerpt,
+      created_at: memory.created_at,
+      updated_at: memory.updated_at,
+      retention_until: memory.retention_until,
+      score,
+      score_reasons,
+    },
+  }
+}
+
+export class LocalMemoryStore {
+  private dbPath: string
+  private db: InstanceType<typeof DatabaseSync> | null = null
+  private initialized = false
+
+  constructor() {
+    this.dbPath = path.join(app.getPath('userData'), STORAGE_DIR, DB_FILE)
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    await fs.mkdir(path.dirname(this.dbPath), { recursive: true })
+
+    this.db = new DatabaseSync(this.dbPath)
+    this.db.exec('PRAGMA journal_mode = WAL;')
+    this.db.exec('PRAGMA foreign_keys = ON;')
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        memory_type TEXT NOT NULL,
+        source_platform TEXT,
+        source_excerpt TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        confidence REAL NOT NULL,
+        importance REAL NOT NULL,
+        sensitivity_level TEXT NOT NULL,
+        retention_until INTEGER,
+        status TEXT NOT NULL,
+        user_control TEXT NOT NULL,
+        why_stored TEXT,
+        conflict_state TEXT NOT NULL DEFAULT 'none',
+        conflict_notes TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memories_status ON memories(status);
+      CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
+      CREATE INDEX IF NOT EXISTS idx_memories_platform ON memories(source_platform);
+      CREATE INDEX IF NOT EXISTS idx_memories_updated_at ON memories(updated_at);
+
+      CREATE TABLE IF NOT EXISTS memory_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        previous_status TEXT,
+        new_status TEXT,
+        reason TEXT,
+        payload_json TEXT,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (memory_id) REFERENCES memories(id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_memory_events_memory_id ON memory_events(memory_id);
+      CREATE INDEX IF NOT EXISTS idx_memory_events_created_at ON memory_events(created_at);
+    `)
+
+    this.ensureColumn('memories', 'conflict_state', `ALTER TABLE memories ADD COLUMN conflict_state TEXT NOT NULL DEFAULT 'none'`)
+    this.ensureColumn('memories', 'conflict_notes', 'ALTER TABLE memories ADD COLUMN conflict_notes TEXT')
+
+    this.initialized = true
+    console.log('[LocalMemoryStore] Initialized')
+  }
+
+  private ensureColumn(tableName: string, columnName: string, alterSql: string): void {
+    const db = this.getDatabase()
+    const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>
+    if (!columns.some((column) => column.name === columnName)) {
+      db.exec(alterSql)
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      await this.initialize()
+    }
+  }
+
+  private getDatabase() {
+    if (!this.db) {
+      throw new Error('[LocalMemoryStore] Database is not initialized')
+    }
+    return this.db
+  }
+
+  async createMemory(input: CreateLocalMemoryInput): Promise<LocalMemoryItem> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+    const now = Date.now()
+    const sensitivity = inferSensitivityLevel(input.content, input.source_platform, input.sensitivity_level)
+
+    const record: LocalMemoryItem = {
+      id: input.id ?? generateMemoryId(),
+      content: input.content,
+      memory_type: input.memory_type,
+      source_platform: input.source_platform ?? null,
+      source_excerpt: input.source_excerpt ?? null,
+      created_at: now,
+      updated_at: now,
+      confidence: clampScore(input.confidence, 0.5),
+      importance: clampScore(input.importance, 0.5),
+      sensitivity_level: sensitivity,
+      retention_until: defaultRetentionUntil(sensitivity, input.retention_until),
+      status: input.status ?? 'active',
+      user_control: input.user_control ?? 'auto',
+      why_stored: input.why_stored ?? null,
+      conflict_state: input.conflict_state ?? 'none',
+      conflict_notes: input.conflict_notes ?? null,
+    }
+
+    db.prepare(`
+      INSERT INTO memories (
+        id, content, memory_type, source_platform, source_excerpt, created_at, updated_at,
+        confidence, importance, sensitivity_level, retention_until, status, user_control, why_stored,
+        conflict_state, conflict_notes
+      ) VALUES (
+        @id, @content, @memory_type, @source_platform, @source_excerpt, @created_at, @updated_at,
+        @confidence, @importance, @sensitivity_level, @retention_until, @status, @user_control, @why_stored,
+        @conflict_state, @conflict_notes
+      )
+    `).run(record as unknown as Record<string, unknown>)
+
+    await this.createEvent({
+      memory_id: record.id,
+      event_type: 'created',
+      actor: 'system',
+      previous_status: null,
+      new_status: record.status,
+      reason: 'Local memory record created',
+      payload_json: JSON.stringify({
+        memory_type: record.memory_type,
+        source_platform: record.source_platform,
+        user_control: record.user_control,
+        sensitivity_level: record.sensitivity_level,
+      }),
+      created_at: now,
+    })
+
+    await this.recalculateConflictsForMemory(record.id)
+    return (await this.getMemoryById(record.id)) ?? record
+  }
+
+  async getMemoryById(id: string): Promise<LocalMemoryItem | null> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+    const row = db.prepare('SELECT * FROM memories WHERE id = ?').get<LocalMemoryItem>([id])
+    return row ?? null
+  }
+
+  async getExplainedMemoryById(id: string): Promise<ExplainedLocalMemoryItem | null> {
+    const memory = await this.getMemoryById(id)
+    return memory ? attachExplanation(memory) : null
+  }
+
+  async listMemories(filters: LocalMemoryListFilters = {}): Promise<LocalMemoryItem[]> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+
+    const clauses: string[] = ['(retention_until IS NULL OR retention_until >= @now)']
+    const params: Record<string, unknown> = { now: Date.now() }
+
+    if (filters.status) {
+      clauses.push('status = @status')
+      params.status = filters.status
+    } else {
+      clauses.push('status != "deleted"')
+    }
+    if (filters.memory_type) {
+      clauses.push('memory_type = @memory_type')
+      params.memory_type = filters.memory_type
+    }
+    if (filters.source_platform) {
+      clauses.push('source_platform = @source_platform')
+      params.source_platform = filters.source_platform
+    }
+    if (filters.sensitivity_level) {
+      clauses.push('sensitivity_level = @sensitivity_level')
+      params.sensitivity_level = filters.sensitivity_level
+    }
+    if (filters.user_control) {
+      clauses.push('user_control = @user_control')
+      params.user_control = filters.user_control
+    }
+    if (filters.created_after != null) {
+      clauses.push('created_at >= @created_after')
+      params.created_after = filters.created_after
+    }
+    if (filters.created_before != null) {
+      clauses.push('created_at <= @created_before')
+      params.created_before = filters.created_before
+    }
+    if (filters.updated_after != null) {
+      clauses.push('updated_at >= @updated_after')
+      params.updated_after = filters.updated_after
+    }
+    if (filters.updated_before != null) {
+      clauses.push('updated_at <= @updated_before')
+      params.updated_before = filters.updated_before
+    }
+    if (filters.min_confidence != null) {
+      clauses.push('confidence >= @min_confidence')
+      params.min_confidence = clampScore(filters.min_confidence, 0)
+    }
+    if (filters.min_importance != null) {
+      clauses.push('importance >= @min_importance')
+      params.min_importance = clampScore(filters.min_importance, 0)
+    }
+    if (filters.conflict_state) {
+      clauses.push('conflict_state = @conflict_state')
+      params.conflict_state = filters.conflict_state
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''
+
+    return db.prepare(`SELECT * FROM memories ${whereClause} ORDER BY updated_at DESC, created_at DESC`).all<LocalMemoryItem>(params)
+  }
+
+  async listExplainedMemories(filters: LocalMemoryListFilters = {}): Promise<ExplainedLocalMemoryItem[]> {
+    const memories = await this.listMemories(filters)
+    return memories.map(attachExplanation)
+  }
+
+  async searchMemories(filters: MemorySearchFilters = {}): Promise<MemoryRetrievalResult[]> {
+    const { query = '', limit = 20, include_archived = false, exclude_sensitive = false, ...listFilters } = filters
+    const baseFilters: LocalMemoryListFilters = { ...listFilters }
+    if (!include_archived && !baseFilters.status) {
+      baseFilters.status = 'active'
+    }
+
+    let memories = await this.listMemories(baseFilters)
+    if (exclude_sensitive) {
+      memories = memories.filter((memory) => memory.sensitivity_level !== 'sensitive')
+    }
+
+    const now = Date.now()
+    const scored = memories
+      .map((memory) => scoreMemoryMatch(memory, query, now))
+      .filter((result): result is MemoryRetrievalResult => result !== null)
+      .sort((a, b) => b.retrieval_explanation.score - a.retrieval_explanation.score)
+
+    return scored.slice(0, Math.max(1, limit))
+  }
+
+  async updateMemory(id: string, updates: UpdateLocalMemoryInput): Promise<LocalMemoryItem | null> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+    const existing = await this.getMemoryById(id)
+
+    if (!existing) {
+      return null
+    }
+
+    const nextSensitivity = inferSensitivityLevel(
+      updates.content ?? existing.content,
+      updates.source_platform ?? existing.source_platform,
+      updates.sensitivity_level ?? existing.sensitivity_level
+    )
+    const requestedRetentionUntil = hasOwnProperty(updates, 'retention_until')
+      ? updates.retention_until ?? null
+      : existing.retention_until
+    const next: LocalMemoryItem = {
+      ...existing,
+      ...updates,
+      confidence: updates.confidence != null ? clampScore(updates.confidence, existing.confidence) : existing.confidence,
+      importance: updates.importance != null ? clampScore(updates.importance, existing.importance) : existing.importance,
+      sensitivity_level: nextSensitivity,
+      retention_until: defaultRetentionUntil(nextSensitivity, requestedRetentionUntil),
+      conflict_state: updates.conflict_state ?? existing.conflict_state,
+      conflict_notes: updates.conflict_notes ?? existing.conflict_notes,
+      updated_at: Date.now(),
+    }
+
+    db.prepare(`
+      UPDATE memories
+      SET
+        content = @content,
+        memory_type = @memory_type,
+        source_platform = @source_platform,
+        source_excerpt = @source_excerpt,
+        updated_at = @updated_at,
+        confidence = @confidence,
+        importance = @importance,
+        sensitivity_level = @sensitivity_level,
+        retention_until = @retention_until,
+        status = @status,
+        user_control = @user_control,
+        why_stored = @why_stored,
+        conflict_state = @conflict_state,
+        conflict_notes = @conflict_notes
+      WHERE id = @id
+    `).run(next as unknown as Record<string, unknown>)
+
+    await this.createEvent({
+      memory_id: id,
+      event_type: 'updated',
+      actor: 'system',
+      previous_status: existing.status,
+      new_status: next.status,
+      reason: 'Local memory record updated',
+      payload_json: JSON.stringify({ updates }),
+    })
+
+    await this.recalculateConflictsForMemory(id)
+    return (await this.getMemoryById(id)) ?? next
+  }
+
+  async deleteMemory(id: string): Promise<boolean> {
+    await this.ensureInitialized()
+    const existing = await this.getMemoryById(id)
+
+    if (!existing) {
+      return false
+    }
+
+    const updated = await this.updateMemory(id, {
+      status: 'deleted',
+      user_control: 'deleted',
+      why_stored: existing.why_stored,
+    })
+
+    await this.createEvent({
+      memory_id: id,
+      event_type: 'deleted',
+      actor: 'system',
+      previous_status: existing.status,
+      new_status: 'deleted',
+      reason: 'Local memory record soft-deleted',
+      payload_json: JSON.stringify({ id }),
+    })
+
+    return !!updated
+  }
+
+  async deleteMemoriesBySource(sourcePlatform: string): Promise<number> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+    const existing = db.prepare(`
+      SELECT * FROM memories
+      WHERE source_platform = @source_platform AND status != 'deleted'
+      ORDER BY updated_at DESC
+    `).all({ source_platform: sourcePlatform }) as LocalMemoryItem[]
+
+    for (const memory of existing) {
+      await this.updateMemory(memory.id, {
+        status: 'deleted',
+        user_control: 'deleted',
+      })
+      await this.createEvent({
+        memory_id: memory.id,
+        event_type: 'deleted_by_source',
+        actor: 'system',
+        previous_status: memory.status,
+        new_status: 'deleted',
+        reason: `Deleted memories by source platform: ${sourcePlatform}`,
+        payload_json: JSON.stringify({ source_platform: sourcePlatform, id: memory.id }),
+      })
+    }
+
+    return existing.length
+  }
+
+  async hasSuppressedMatch(content: string, sourcePlatform?: string | null): Promise<boolean> {
+    await this.ensureInitialized()
+    const normalized = normalizeComparableText(content)
+    const candidates = await this.listMemories({ user_control: 'dont_remember' })
+
+    return candidates.some((memory) => {
+      if (sourcePlatform && memory.source_platform && memory.source_platform !== sourcePlatform) {
+        return false
+      }
+      const candidate = normalizeComparableText(memory.content)
+      return candidate === normalized || candidate.includes(normalized) || normalized.includes(candidate)
+    })
+  }
+
+  private async recalculateConflictsForMemory(targetId: string): Promise<void> {
+    const target = await this.getMemoryById(targetId)
+    if (!target) return
+
+    const impactedPeerIds = new Set<string>(this.extractConflictPeerIds(target.conflict_notes))
+    await this.clearConflictState(target.id)
+
+    if (target.status === 'deleted' || target.user_control === 'dont_remember') {
+      for (const peerId of impactedPeerIds) {
+        await this.rebuildConflictState(peerId)
+      }
+      return
+    }
+    if (target.memory_type === 'conversation_message' || target.memory_type === 'suppression_rule') {
+      for (const peerId of impactedPeerIds) {
+        await this.rebuildConflictState(peerId)
+      }
+      return
+    }
+
+    const peers = await this.listMemories({ memory_type: target.memory_type })
+    const targetFact = parseFactSignature(target.content)
+
+    for (const peer of peers) {
+      if (peer.id === target.id || peer.status === 'deleted') continue
+      if (peer.source_platform && target.source_platform && peer.source_platform !== target.source_platform) continue
+
+      let isConflict = false
+      let note = ''
+
+      const peerFact = parseFactSignature(peer.content)
+      if (targetFact && peerFact && targetFact.subject === peerFact.subject && targetFact.relation === peerFact.relation && targetFact.value !== peerFact.value) {
+        isConflict = true
+        note = `Conflicts with ${peer.id}: same subject and relation, different value`
+      } else {
+        const similarity = computeJaccardSimilarity(target.content, peer.content)
+        const sameNormalized = normalizeComparableText(target.content) === normalizeComparableText(peer.content)
+        if (!sameNormalized && similarity >= 0.35 && similarity < 0.95) {
+          isConflict = true
+          note = `Potentially conflicts with ${peer.id}: overlap similarity ${similarity.toFixed(2)}`
+        }
+      }
+
+      impactedPeerIds.add(peer.id)
+      if (!isConflict) {
+        continue
+      }
+
+      const targetConflictState: MemoryConflictState = note.startsWith('Conflicts with') ? 'confirmed' : 'potential'
+      const targetConfidence = clampScore(target.confidence - (targetConflictState === 'confirmed' ? 0.2 : 0.1), target.confidence)
+
+      await this.applyConflictUpdate(target.id, targetConflictState, note, targetConfidence)
+    }
+
+    for (const peerId of impactedPeerIds) {
+      await this.rebuildConflictState(peerId)
+    }
+  }
+
+  private async rebuildConflictState(id: string): Promise<void> {
+    const memory = await this.getMemoryById(id)
+    if (!memory || memory.status === 'deleted' || memory.user_control === 'dont_remember') return
+    if (memory.memory_type === 'conversation_message' || memory.memory_type === 'suppression_rule') return
+
+    await this.clearConflictState(memory.id)
+
+    const peers = await this.listMemories({ memory_type: memory.memory_type })
+    for (const peer of peers) {
+      if (peer.id === memory.id || peer.status === 'deleted') continue
+      if (peer.source_platform && memory.source_platform && peer.source_platform !== memory.source_platform) continue
+
+      let isConflict = false
+      let note = ''
+      const memoryFact = parseFactSignature(memory.content)
+      const peerFact = parseFactSignature(peer.content)
+      if (memoryFact && peerFact && memoryFact.subject === peerFact.subject && memoryFact.relation === peerFact.relation && memoryFact.value !== peerFact.value) {
+        isConflict = true
+        note = `Conflicts with ${peer.id}: same subject and relation, different value`
+      } else {
+        const similarity = computeJaccardSimilarity(memory.content, peer.content)
+        const sameNormalized = normalizeComparableText(memory.content) === normalizeComparableText(peer.content)
+        if (!sameNormalized && similarity >= 0.35 && similarity < 0.95) {
+          isConflict = true
+          note = `Potentially conflicts with ${peer.id}: overlap similarity ${similarity.toFixed(2)}`
+        }
+      }
+
+      if (!isConflict) continue
+
+      const conflictState: MemoryConflictState = note.startsWith('Conflicts with') ? 'confirmed' : 'potential'
+      const nextConfidence = clampScore(memory.confidence - (conflictState === 'confirmed' ? 0.2 : 0.1), memory.confidence)
+      await this.applyConflictUpdate(memory.id, conflictState, note, nextConfidence)
+    }
+  }
+
+  private extractConflictPeerIds(notes?: string | null): string[] {
+    if (!notes) return []
+
+    const ids = new Set<string>()
+    const patterns = [
+      /Conflicts with ([^:\s;]+)/g,
+      /Potentially conflicts with ([^:\s;]+)/g,
+      /Potential conflict with ([^:\s;]+)/g,
+    ]
+
+    for (const pattern of patterns) {
+      for (const match of notes.matchAll(pattern)) {
+        const peerId = match[1]?.trim()
+        if (peerId) {
+          ids.add(peerId)
+        }
+      }
+    }
+
+    return Array.from(ids)
+  }
+
+  private async clearConflictState(id: string): Promise<void> {
+    const memory = await this.getMemoryById(id)
+    if (!memory || (memory.conflict_state === 'none' && !memory.conflict_notes)) return
+
+    const db = this.getDatabase()
+    db.prepare(`
+      UPDATE memories
+      SET conflict_state = 'none', conflict_notes = NULL, updated_at = @updated_at
+      WHERE id = @id
+    `).run({
+      id,
+      updated_at: Date.now(),
+    })
+  }
+
+  private async applyConflictUpdate(id: string, conflictState: MemoryConflictState, note: string, confidence: number): Promise<void> {
+    const memory = await this.getMemoryById(id)
+    if (!memory || memory.status === 'deleted') return
+    const existingNotes = memory.conflict_notes
+      ? memory.conflict_notes.split(';').map((item) => item.trim()).filter(Boolean)
+      : []
+    const dedupedNotes = Array.from(new Set([...existingNotes, note.trim()]))
+    const nextNotes = dedupedNotes.join('; ')
+    const nextState: MemoryConflictState = memory.conflict_state === 'confirmed' || conflictState === 'confirmed'
+      ? 'confirmed'
+      : conflictState
+
+    const db = this.getDatabase()
+    db.prepare(`
+      UPDATE memories
+      SET conflict_state = @conflict_state, conflict_notes = @conflict_notes, confidence = @confidence, updated_at = @updated_at
+      WHERE id = @id
+    `).run({
+      id,
+      conflict_state: nextState,
+      conflict_notes: excerptText(nextNotes, 500),
+      confidence,
+      updated_at: Date.now(),
+    })
+
+    await this.createEvent({
+      memory_id: id,
+      event_type: 'conflict_detected',
+      actor: 'system',
+      previous_status: memory.status,
+      new_status: memory.status,
+      reason: note,
+      payload_json: JSON.stringify({ conflict_state: nextState, confidence }),
+    })
+  }
+
+  async createEvent(input: CreateMemoryEventInput): Promise<MemoryEventRecord> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+    const now = input.created_at ?? Date.now()
+
+    const result = db.prepare(`
+      INSERT INTO memory_events (
+        memory_id, event_type, actor, previous_status, new_status, reason, payload_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run([
+      input.memory_id,
+      input.event_type,
+      input.actor ?? 'system',
+      input.previous_status ?? null,
+      input.new_status ?? null,
+      input.reason ?? null,
+      input.payload_json ?? null,
+      now,
+    ])
+
+    return {
+      id: Number(result.lastInsertRowid ?? 0),
+      memory_id: input.memory_id,
+      event_type: input.event_type,
+      actor: input.actor ?? 'system',
+      previous_status: input.previous_status ?? null,
+      new_status: input.new_status ?? null,
+      reason: input.reason ?? null,
+      payload_json: input.payload_json ?? null,
+      created_at: now,
+    }
+  }
+
+  async listEvents(memoryId: string): Promise<MemoryEventRecord[]> {
+    await this.ensureInitialized()
+    const db = this.getDatabase()
+
+    return db.prepare('SELECT * FROM memory_events WHERE memory_id = ? ORDER BY created_at DESC, id DESC').all<MemoryEventRecord>([memoryId])
+  }
+
+  async getProvenanceById(id: string): Promise<MemoryProvenance | null> {
+    const memory = await this.getMemoryById(id)
+    return memory ? buildProvenance(memory) : null
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close()
+      this.db = null
+      this.initialized = false
+    }
+  }
+}
+
+export const localMemoryStore = new LocalMemoryStore()

--- a/src/main/services/memory/memory-provider.ts
+++ b/src/main/services/memory/memory-provider.ts
@@ -1,0 +1,20 @@
+import type { StoredUnmemorizedMessage } from '../memorization.storage'
+
+export type MemoryProviderResult =
+  | { status: 'success' }
+  | { status: 'failure' }
+  | { status: 'pending' }
+  | { status: 'error' }
+
+export interface MemoryProvider {
+  readonly kind: string
+
+  isConfigured(): Promise<boolean>
+
+  startMemorization(messages: StoredUnmemorizedMessage[]): Promise<{
+    taskId: string | null
+    messageCount: number
+  }>
+
+  checkTaskStatus(taskId: string, messageCount: number): Promise<MemoryProviderResult>
+}

--- a/src/main/services/memory/remote-memu.provider.ts
+++ b/src/main/services/memory/remote-memu.provider.ts
@@ -1,0 +1,125 @@
+import { loadSettings } from '../../config/settings.config'
+import type { StoredUnmemorizedMessage } from '../memorization.storage'
+import type { MemoryProvider, MemoryProviderResult } from './memory-provider'
+
+type MemorizeStatus = 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'FAILURE'
+
+interface MemorizeStatusResponse {
+  task_id: string
+  status: MemorizeStatus
+  detail_info: string
+}
+
+export class RemoteMemuProvider implements MemoryProvider {
+  readonly kind = 'remote-memu'
+
+  private async getMemuConfig() {
+    const settings = await loadSettings()
+    return {
+      baseUrl: settings.memuBaseUrl,
+      apiKey: settings.memuApiKey,
+      userId: settings.memuUserId,
+      agentId: settings.memuAgentId,
+    }
+  }
+
+  async isConfigured(): Promise<boolean> {
+    const settings = await loadSettings()
+    return !!(
+      settings.memuApiKey && settings.memuApiKey.trim() &&
+      settings.memuBaseUrl && settings.memuBaseUrl.trim() &&
+      settings.memuUserId && settings.memuUserId.trim() &&
+      settings.memuAgentId && settings.memuAgentId.trim()
+    )
+  }
+
+  async startMemorization(messages: StoredUnmemorizedMessage[]): Promise<{
+    taskId: string | null
+    messageCount: number
+  }> {
+    const memuConfig = await this.getMemuConfig()
+    const formattedMessages = messages.map((m) => ({
+      role: m.role,
+      content: `[${m.platform}] ${m.content}`,
+    }))
+
+    console.log(`[Memorization] Sending ${formattedMessages.length} messages to memorize`)
+
+    const response = await fetch(`${memuConfig.baseUrl}/api/v3/memory/memorize`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${memuConfig.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id: memuConfig.userId,
+        agent_id: memuConfig.agentId,
+        conversation: formattedMessages,
+      }),
+    })
+
+    if (!response.ok) {
+      console.error('[Memorization] API returned status:', response.status)
+      return {
+        taskId: null,
+        messageCount: messages.length,
+      }
+    }
+
+    const result = (await response.json()) as { task_id?: string }
+    const taskId = result.task_id
+
+    if (!taskId) {
+      console.error('[Memorization] No task_id returned')
+      return {
+        taskId: null,
+        messageCount: messages.length,
+      }
+    }
+
+    console.log(`[Memorization] Task started: ${taskId}`)
+
+    return {
+      taskId,
+      messageCount: messages.length,
+    }
+  }
+
+  async checkTaskStatus(taskId: string, messageCount: number): Promise<MemoryProviderResult> {
+    try {
+      const memuConfig = await this.getMemuConfig()
+      const response = await fetch(
+        `${memuConfig.baseUrl}/api/v3/memory/memorize/status/${taskId}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${memuConfig.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+
+      if (!response.ok) {
+        console.error(`[Memorization] Status check failed for ${taskId}: ${response.status}`)
+        return { status: 'error' }
+      }
+
+      const result = (await response.json()) as MemorizeStatusResponse
+      console.log(`[Memorization] Task ${taskId} status: ${result.status}`)
+
+      if (result.status === 'SUCCESS') {
+        return { status: 'success' }
+      }
+
+      if (result.status === 'FAILURE') {
+        console.error(`[Memorization] Task ${taskId} failed: ${result.detail_info}`)
+        return { status: 'failure' }
+      }
+
+      return { status: 'pending' }
+    } catch (error) {
+      console.error(`[Memorization] Error checking task ${taskId}:`, error)
+      return { status: 'error' }
+    }
+  }
+}

--- a/src/main/services/proactive.service.ts
+++ b/src/main/services/proactive.service.ts
@@ -1,6 +1,7 @@
 import Anthropic from '@anthropic-ai/sdk'
 import OpenAI from 'openai'
 import { loadSettings } from '../config/settings.config'
+import { localMemoryControlService } from './local-memory-control.service'
 import { runOpenAIAdapter } from './agent/openai-adapter'
 import { runGeminiAdapter, createToolUseIdMap } from './agent/gemini-adapter'
 import { detectCustomProtocol } from './agent/utils'
@@ -202,6 +203,26 @@ class ProactiveService {
   private async executeMemuMemory(query: string): Promise<{ success: boolean; data?: unknown; error?: string }> {
     try {
       const memuConfig = await this.getMemuConfig()
+      const hasRemoteConfig = !!(memuConfig.apiKey && memuConfig.apiKey.trim())
+
+      if (!hasRemoteConfig) {
+        const results = await localMemoryControlService.searchMemories({
+          query,
+          limit: 10,
+          include_archived: false,
+          min_confidence: 0.2,
+          exclude_sensitive: true,
+        })
+        return {
+          success: true,
+          data: {
+            source: 'local-controlled-memory',
+            query,
+            results,
+          },
+        }
+      }
+
       const response = await fetch(`${memuConfig.baseUrl}/api/v3/memory/retrieve`, {
         method: 'POST',
         headers: {

--- a/src/main/tools/memu.executor.ts
+++ b/src/main/tools/memu.executor.ts
@@ -1,3 +1,6 @@
+import { loadSettings } from '../config/settings.config'
+import { localMemoryControlService } from '../services/local-memory-control.service'
+
 type ToolResult = { success: boolean; data?: unknown; error?: string }
 
 export interface MemuConfig {
@@ -7,11 +10,7 @@ export interface MemuConfig {
   agentId: string
 }
 
-/**
- * Get Memu API config from settings.
- */
 async function getMemuConfig(): Promise<MemuConfig> {
-  const { loadSettings } = await import('../config/settings.config')
   const settings = await loadSettings()
 
   return {
@@ -22,12 +21,41 @@ async function getMemuConfig(): Promise<MemuConfig> {
   }
 }
 
-/**
- * Execute memu_memory: retrieve memory by query from the Memu API.
- */
+function hasRemoteConfig(config: MemuConfig): boolean {
+  return !!(config.apiKey && config.apiKey.trim())
+}
+
+async function executeLocalMemory(query: string): Promise<ToolResult> {
+  try {
+    const results = await localMemoryControlService.searchMemories({
+      query,
+      limit: 10,
+      include_archived: false,
+      exclude_sensitive: true,
+      min_confidence: 0.2,
+    })
+
+    return {
+      success: true,
+      data: {
+        source: 'local-controlled-memory',
+        query,
+        results,
+      },
+    }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
 export async function executeMemuMemory(query: string): Promise<ToolResult> {
   try {
     const memuConfig = await getMemuConfig()
+
+    if (!hasRemoteConfig(memuConfig)) {
+      return await executeLocalMemory(query)
+    }
+
     const response = await fetch(`${memuConfig.baseUrl}/api/v3/memory/retrieve`, {
       method: 'POST',
       headers: {
@@ -40,16 +68,28 @@ export async function executeMemuMemory(query: string): Promise<ToolResult> {
         query
       })
     })
-    const result = await response.json()
+
+    let result: unknown = null
+    try {
+      result = await response.json()
+    } catch {
+      result = null
+    }
+
+    if (!response.ok) {
+      const message =
+        typeof result === 'object' && result && 'message' in result && typeof (result as { message?: unknown }).message === 'string'
+          ? (result as { message: string }).message
+          : `memU retrieve failed with HTTP ${response.status}`
+      return { success: false, error: message }
+    }
+
     return { success: true, data: result }
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : String(error) }
   }
 }
 
-/**
- * Execute a Memu tool by name
- */
 export async function executeMemuTool(name: string, input: unknown): Promise<ToolResult> {
   switch (name) {
     case 'memu_memory': {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,11 @@ interface IpcResponse<T = unknown> {
   error?: string
 }
 
+type MemoryStatus = 'active' | 'archived' | 'deleted'
+type MemoryUserControl = 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+type MemorySensitivityLevel = 'normal' | 'work' | 'sensitive'
+type MemoryConflictState = 'none' | 'potential' | 'confirmed'
+
 // Conversation message type
 interface ConversationMessage {
   role: 'user' | 'assistant'
@@ -558,6 +563,148 @@ interface UpdateDownloadProgress {
   total: number
 }
 
+
+
+// Local controlled memory types
+interface LocalMemoryItem {
+  id: string
+  content: string
+  memory_type: string
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  confidence: number
+  importance: number
+  sensitivity_level: MemorySensitivityLevel
+  retention_until: number | null
+  status: 'active' | 'archived' | 'deleted'
+  user_control: 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+  why_stored: string | null
+  conflict_state: 'none' | 'potential' | 'confirmed'
+  conflict_notes: string | null
+}
+
+interface MemoryProvenance {
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  retention_until: number | null
+  why_stored: string | null
+  sensitivity_level: MemorySensitivityLevel
+  conflict_state: 'none' | 'potential' | 'confirmed'
+  conflict_notes: string | null
+}
+
+interface MemoryExplanation {
+  provenance: MemoryProvenance
+}
+
+interface ExplainedLocalMemoryItem extends LocalMemoryItem {
+  explanation: MemoryExplanation
+}
+
+interface MemoryMatchField {
+  field: 'content' | 'memory_type' | 'source_platform' | 'source_excerpt' | 'why_stored' | 'status' | 'user_control' | 'sensitivity_level' | 'conflict_notes'
+  value_excerpt: string
+  matched_terms: string[]
+  score_contribution: number
+  reason: string
+}
+
+interface MemoryRetrievalExplanation {
+  query: string
+  matched_fields: MemoryMatchField[]
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  retention_until: number | null
+  score: number
+  score_reasons: string[]
+}
+
+interface MemoryRetrievalResult {
+  memory: ExplainedLocalMemoryItem
+  retrieval_explanation: MemoryRetrievalExplanation
+}
+
+interface MemoryEventRecord {
+  id: number
+  memory_id: string
+  event_type: string
+  actor: string
+  previous_status: MemoryStatus | null
+  new_status: MemoryStatus | null
+  reason: string | null
+  payload_json: string | null
+  created_at: number
+}
+
+interface MemoryCaptureStatus {
+  paused: boolean
+}
+
+interface RememberThisInput {
+  content: string
+  memory_type: string
+  source_platform?: string | null
+  source_excerpt?: string | null
+  confidence?: number
+  importance?: number
+  sensitivity_level?: MemorySensitivityLevel
+  retention_until?: number | null
+  status?: 'active' | 'archived' | 'deleted'
+  user_control?: 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+  why_stored?: string | null
+}
+
+interface DoNotRememberInput {
+  content: string
+  memory_type?: string
+  source_platform?: string | null
+  source_excerpt?: string | null
+  sensitivity_level?: MemorySensitivityLevel
+  reason?: string | null
+}
+
+interface MemorySearchInput {
+  query?: string
+  limit?: number
+  include_archived?: boolean
+  status?: 'active' | 'archived' | 'deleted'
+  memory_type?: string
+  source_platform?: string
+  sensitivity_level?: MemorySensitivityLevel
+  user_control?: 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+  created_after?: number
+  created_before?: number
+  updated_after?: number
+  updated_before?: number
+  min_confidence?: number
+  min_importance?: number
+  exclude_sensitive?: boolean
+  conflict_state?: MemoryConflictState
+}
+
+interface MemoryApi {
+  getStatus: () => Promise<IpcResponse<MemoryCaptureStatus>>
+  rememberThis: (input: RememberThisInput) => Promise<IpcResponse<LocalMemoryItem>>
+  doNotRememberThis: (input: DoNotRememberInput) => Promise<IpcResponse<LocalMemoryItem>>
+  get: (id: string) => Promise<IpcResponse<LocalMemoryItem | null>>
+  getExplained: (id: string) => Promise<IpcResponse<ExplainedLocalMemoryItem | null>>
+  getProvenance: (id: string) => Promise<IpcResponse<MemoryProvenance | null>>
+  list: (filters?: Record<string, unknown>) => Promise<IpcResponse<LocalMemoryItem[]>>
+  listExplained: (filters?: Record<string, unknown>) => Promise<IpcResponse<ExplainedLocalMemoryItem[]>>
+  search: (filters?: MemorySearchInput) => Promise<IpcResponse<MemoryRetrievalResult[]>>
+  update: (id: string, updates: Record<string, unknown>) => Promise<IpcResponse<LocalMemoryItem | null>>
+  delete: (id: string) => Promise<IpcResponse<{ deleted: boolean }>>
+  deleteBySource: (sourcePlatform: string) => Promise<IpcResponse<{ deletedCount: number }>>
+  listEvents: (memoryId: string) => Promise<IpcResponse<MemoryEventRecord[]>>
+  pauseCapture: (reason?: string) => Promise<IpcResponse<MemoryCaptureStatus>>
+  resumeCapture: (reason?: string) => Promise<IpcResponse<MemoryCaptureStatus>>
+}
+
 // Updater API interface (auto-update)
 interface UpdaterApi {
   checkForUpdates: () => Promise<IpcResponse>
@@ -585,5 +732,6 @@ declare global {
     skills: SkillsApi
     services: ServicesApi
     updater: UpdaterApi
+    memory: MemoryApi
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -322,6 +322,27 @@ const servicesApi = {
   }
 }
 
+
+
+// Memory API (local controlled memory actions)
+const memoryApi = {
+  getStatus: () => ipcRenderer.invoke('memory:get-status'),
+  rememberThis: (input: unknown) => ipcRenderer.invoke('memory:remember-this', input),
+  doNotRememberThis: (input: unknown) => ipcRenderer.invoke('memory:do-not-remember-this', input),
+  get: (id: string) => ipcRenderer.invoke('memory:get', id),
+  getExplained: (id: string) => ipcRenderer.invoke('memory:get-explained', id),
+  getProvenance: (id: string) => ipcRenderer.invoke('memory:get-provenance', id),
+  list: (filters?: unknown) => ipcRenderer.invoke('memory:list', filters),
+  listExplained: (filters?: unknown) => ipcRenderer.invoke('memory:list-explained', filters),
+  search: (filters?: unknown) => ipcRenderer.invoke('memory:search', filters),
+  update: (id: string, updates: unknown) => ipcRenderer.invoke('memory:update', id, updates),
+  delete: (id: string) => ipcRenderer.invoke('memory:delete', id),
+  deleteBySource: (sourcePlatform: string) => ipcRenderer.invoke('memory:delete-by-source', sourcePlatform),
+  listEvents: (memoryId: string) => ipcRenderer.invoke('memory:list-events', memoryId),
+  pauseCapture: (reason?: string) => ipcRenderer.invoke('memory:pause-capture', reason),
+  resumeCapture: (reason?: string) => ipcRenderer.invoke('memory:resume-capture', reason),
+}
+
 // Updater API (auto-update)
 const updaterApi = {
   checkForUpdates: () => ipcRenderer.invoke('updater:check-for-updates'),
@@ -356,6 +377,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('skills', skillsApi)
     contextBridge.exposeInMainWorld('services', servicesApi)
     contextBridge.exposeInMainWorld('updater', updaterApi)
+    contextBridge.exposeInMainWorld('memory', memoryApi)
   } catch (error) {
     console.error(error)
   }
@@ -396,4 +418,6 @@ if (process.contextIsolated) {
   window.services = servicesApi
   // @ts-ignore (define in dts)
   window.updater = updaterApi
+  // @ts-ignore (define in dts)
+  window.memory = memoryApi
 }

--- a/src/renderer/src/components/Settings/DataSettings/LocalMemorySettings.tsx
+++ b/src/renderer/src/components/Settings/DataSettings/LocalMemorySettings.tsx
@@ -1,0 +1,1085 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Brain,
+  Clock3,
+  Eye,
+  EyeOff,
+  FileClock,
+  Filter,
+  PauseCircle,
+  Pencil,
+  RefreshCw,
+  Save,
+  Search,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldEllipsis,
+  Trash2,
+  PlayCircle,
+  History,
+  Ban,
+  Database,
+} from 'lucide-react'
+import { MessageDisplay } from '../shared'
+
+type MessageState = { type: 'success' | 'error'; text: string } | null
+type MemoryStatus = 'active' | 'archived' | 'deleted'
+type MemorySensitivityLevel = 'normal' | 'work' | 'sensitive'
+type MemoryConflictState = 'none' | 'potential' | 'confirmed'
+
+interface MemoryProvenance {
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  retention_until: number | null
+  why_stored: string | null
+  sensitivity_level: MemorySensitivityLevel
+  conflict_state: MemoryConflictState
+  conflict_notes: string | null
+}
+
+interface MemoryExplanation {
+  provenance: MemoryProvenance
+}
+
+interface ExplainedLocalMemoryItem {
+  id: string
+  content: string
+  memory_type: string
+  source_platform: string | null
+  source_excerpt: string | null
+  created_at: number
+  updated_at: number
+  confidence: number
+  importance: number
+  sensitivity_level: MemorySensitivityLevel
+  retention_until: number | null
+  status: MemoryStatus
+  user_control: 'auto' | 'remember' | 'dont_remember' | 'modified' | 'deleted' | 'paused'
+  why_stored: string | null
+  conflict_state: MemoryConflictState
+  conflict_notes: string | null
+  explanation: MemoryExplanation
+}
+
+interface MemoryMatchField {
+  field: 'content' | 'memory_type' | 'source_platform' | 'source_excerpt' | 'why_stored' | 'status' | 'user_control' | 'sensitivity_level' | 'conflict_notes'
+  value_excerpt: string
+  matched_terms: string[]
+  score_contribution: number
+  reason: string
+}
+
+interface MemoryRetrievalResult {
+  memory: ExplainedLocalMemoryItem
+  retrieval_explanation: {
+    query: string
+    matched_fields: MemoryMatchField[]
+    source_excerpt: string | null
+    created_at: number
+    updated_at: number
+    retention_until: number | null
+    score: number
+    score_reasons: string[]
+  }
+}
+
+interface MemoryEventRecord {
+  id: number
+  memory_id: string
+  event_type: string
+  actor: string
+  previous_status: MemoryStatus | null
+  new_status: MemoryStatus | null
+  reason: string | null
+  payload_json: string | null
+  created_at: number
+}
+
+type MemoryFiltersState = {
+  query: string
+  memoryType: string
+  sourcePlatform: string
+  sensitivityLevel: '' | MemorySensitivityLevel
+  conflictState: '' | MemoryConflictState
+  minConfidence: string
+  includeArchived: boolean
+  excludeSensitive: boolean
+}
+
+type RememberFormState = {
+  content: string
+  memoryType: string
+  sourcePlatform: string
+  sourceExcerpt: string
+  sensitivityLevel: MemorySensitivityLevel
+  confidence: string
+  importance: string
+  retentionDays: string
+  whyStored: string
+}
+
+type SuppressFormState = {
+  content: string
+  sourcePlatform: string
+  sourceExcerpt: string
+  sensitivityLevel: MemorySensitivityLevel
+  reason: string
+}
+
+type EditDraftState = {
+  content: string
+  memory_type: string
+  source_platform: string
+  source_excerpt: string
+  confidence: string
+  importance: string
+  sensitivity_level: MemorySensitivityLevel
+  retention_until: string
+  status: MemoryStatus
+  why_stored: string
+  conflict_state: MemoryConflictState
+  conflict_notes: string
+}
+
+const DEFAULT_FILTERS: MemoryFiltersState = {
+  query: '',
+  memoryType: '',
+  sourcePlatform: '',
+  sensitivityLevel: '',
+  conflictState: '',
+  minConfidence: '',
+  includeArchived: true,
+  excludeSensitive: false,
+}
+
+const DEFAULT_REMEMBER_FORM: RememberFormState = {
+  content: '',
+  memoryType: 'manual_note',
+  sourcePlatform: '',
+  sourceExcerpt: '',
+  sensitivityLevel: 'normal',
+  confidence: '0.8',
+  importance: '0.6',
+  retentionDays: '',
+  whyStored: 'User explicitly chose to remember this',
+}
+
+const DEFAULT_SUPPRESS_FORM: SuppressFormState = {
+  content: '',
+  sourcePlatform: '',
+  sourceExcerpt: '',
+  sensitivityLevel: 'normal',
+  reason: 'User explicitly chose not to remember this',
+}
+
+function formatDateTime(timestamp: number | null | undefined): string {
+  if (!timestamp) return 'Not set'
+  return new Date(timestamp).toLocaleString()
+}
+
+function formatRetention(timestamp: number | null): string {
+  if (!timestamp) return 'No expiration'
+  const delta = timestamp - Date.now()
+  if (delta <= 0) return `Expired on ${formatDateTime(timestamp)}`
+
+  const days = Math.ceil(delta / (24 * 60 * 60 * 1000))
+  return `${days} day${days === 1 ? '' : 's'} left`
+}
+
+function parseNumericInput(value: string): number | undefined {
+  if (!value.trim()) return undefined
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return undefined
+  return parsed
+}
+
+function toRetentionTimestamp(days: string): number | null | undefined {
+  if (!days.trim()) return undefined
+  const parsed = Number(days)
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined
+  if (parsed === 0) return null
+  return Date.now() + parsed * 24 * 60 * 60 * 1000
+}
+
+function toDatetimeLocalValue(timestamp: number | null): string {
+  if (!timestamp) return ''
+  const date = new Date(timestamp)
+  const offset = date.getTimezoneOffset()
+  const local = new Date(date.getTime() - offset * 60 * 1000)
+  return local.toISOString().slice(0, 16)
+}
+
+function fromDatetimeLocalValue(value: string): number | null | undefined {
+  if (!value.trim()) return undefined
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+function sensitivityBadgeClass(level: MemorySensitivityLevel): string {
+  switch (level) {
+    case 'sensitive':
+      return 'bg-red-500/10 text-red-600 dark:text-red-300 border border-red-500/20'
+    case 'work':
+      return 'bg-amber-500/10 text-amber-600 dark:text-amber-300 border border-amber-500/20'
+    default:
+      return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300 border border-emerald-500/20'
+  }
+}
+
+function conflictBadgeClass(state: MemoryConflictState): string {
+  switch (state) {
+    case 'confirmed':
+      return 'bg-red-500/10 text-red-600 dark:text-red-300 border border-red-500/20'
+    case 'potential':
+      return 'bg-amber-500/10 text-amber-600 dark:text-amber-300 border border-amber-500/20'
+    default:
+      return 'bg-slate-500/10 text-slate-600 dark:text-slate-300 border border-slate-500/20'
+  }
+}
+
+function buildEditDraft(memory: ExplainedLocalMemoryItem): EditDraftState {
+  return {
+    content: memory.content,
+    memory_type: memory.memory_type,
+    source_platform: memory.source_platform ?? '',
+    source_excerpt: memory.source_excerpt ?? '',
+    confidence: String(memory.confidence),
+    importance: String(memory.importance),
+    sensitivity_level: memory.sensitivity_level,
+    retention_until: toDatetimeLocalValue(memory.retention_until),
+    status: memory.status,
+    why_stored: memory.why_stored ?? '',
+    conflict_state: memory.conflict_state,
+    conflict_notes: memory.conflict_notes ?? '',
+  }
+}
+
+export function LocalMemorySettings(): JSX.Element {
+  const [message, setMessage] = useState<MessageState>(null)
+  const [capturePaused, setCapturePaused] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [submittingRemember, setSubmittingRemember] = useState(false)
+  const [submittingSuppress, setSubmittingSuppress] = useState(false)
+  const [bulkDeletingSource, setBulkDeletingSource] = useState(false)
+  const [filters, setFilters] = useState<MemoryFiltersState>(DEFAULT_FILTERS)
+  const [rememberForm, setRememberForm] = useState<RememberFormState>(DEFAULT_REMEMBER_FORM)
+  const [suppressForm, setSuppressForm] = useState<SuppressFormState>(DEFAULT_SUPPRESS_FORM)
+  const [memories, setMemories] = useState<ExplainedLocalMemoryItem[]>([])
+  const [searchResults, setSearchResults] = useState<MemoryRetrievalResult[] | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState<EditDraftState | null>(null)
+  const [savingId, setSavingId] = useState<string | null>(null)
+  const [eventMemoryId, setEventMemoryId] = useState<string | null>(null)
+  const [events, setEvents] = useState<Record<string, MemoryEventRecord[]>>({})
+  const [loadingEventsId, setLoadingEventsId] = useState<string | null>(null)
+
+  const activeMemories = useMemo(
+    () => searchResults?.map((result) => result.memory) ?? memories,
+    [memories, searchResults]
+  )
+
+  const runLoad = useCallback(async (nextFilters: MemoryFiltersState) => {
+    const normalizedQuery = nextFilters.query.trim()
+    const minConfidence = parseNumericInput(nextFilters.minConfidence)
+
+    if (normalizedQuery) {
+      const result = await window.memory.search({
+        query: normalizedQuery,
+        memory_type: nextFilters.memoryType || undefined,
+        source_platform: nextFilters.sourcePlatform || undefined,
+        sensitivity_level: nextFilters.sensitivityLevel || undefined,
+        conflict_state: nextFilters.conflictState || undefined,
+        min_confidence: minConfidence,
+        include_archived: nextFilters.includeArchived,
+        exclude_sensitive: nextFilters.excludeSensitive,
+        limit: 50,
+      })
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to search memories')
+      }
+
+      setSearchResults(result.data ?? [])
+      setMemories([])
+      return
+    }
+
+    const result = await window.memory.listExplained({
+      status: nextFilters.includeArchived ? undefined : 'active',
+      memory_type: nextFilters.memoryType || undefined,
+      source_platform: nextFilters.sourcePlatform || undefined,
+      sensitivity_level: nextFilters.sensitivityLevel || undefined,
+      conflict_state: nextFilters.conflictState || undefined,
+      min_confidence: minConfidence,
+    })
+
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to load memories')
+    }
+
+    let nextMemories = result.data ?? []
+    if (nextFilters.excludeSensitive) {
+      nextMemories = nextMemories.filter((memory) => memory.sensitivity_level !== 'sensitive')
+    }
+
+    setMemories(nextMemories)
+    setSearchResults(null)
+  }, [])
+
+  const refreshAll = useCallback(async (nextFilters = filters, showBusy = false) => {
+    if (showBusy) setRefreshing(true)
+    try {
+      const [status] = await Promise.all([
+        window.memory.getStatus(),
+        runLoad(nextFilters),
+      ])
+
+      if (status.success && status.data) {
+        setCapturePaused(status.data.paused)
+      }
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'Failed to refresh memory controls',
+      })
+    } finally {
+      setLoading(false)
+      if (showBusy) setRefreshing(false)
+    }
+  }, [filters, runLoad])
+
+  useEffect(() => {
+    void refreshAll(filters)
+  }, [filters, refreshAll])
+
+  const updateMessage = (nextMessage: MessageState) => {
+    setMessage(nextMessage)
+    if (nextMessage) {
+      window.setTimeout(() => setMessage(null), 4000)
+    }
+  }
+
+  const handleRememberSubmit = async (): Promise<void> => {
+    if (!rememberForm.content.trim()) {
+      updateMessage({ type: 'error', text: 'Please enter the memory content to store.' })
+      return
+    }
+
+    setSubmittingRemember(true)
+    try {
+      const result = await window.memory.rememberThis({
+        content: rememberForm.content.trim(),
+        memory_type: rememberForm.memoryType.trim() || 'manual_note',
+        source_platform: rememberForm.sourcePlatform.trim() || null,
+        source_excerpt: rememberForm.sourceExcerpt.trim() || null,
+        confidence: parseNumericInput(rememberForm.confidence),
+        importance: parseNumericInput(rememberForm.importance),
+        sensitivity_level: rememberForm.sensitivityLevel,
+        retention_until: toRetentionTimestamp(rememberForm.retentionDays),
+        why_stored: rememberForm.whyStored.trim() || 'User explicitly chose to remember this',
+      })
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to store memory')
+      }
+
+      setRememberForm(DEFAULT_REMEMBER_FORM)
+      updateMessage({ type: 'success', text: 'Memory saved locally.' })
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to save memory' })
+    } finally {
+      setSubmittingRemember(false)
+    }
+  }
+
+  const handleSuppressSubmit = async (): Promise<void> => {
+    if (!suppressForm.content.trim()) {
+      updateMessage({ type: 'error', text: 'Please enter the content you want memU bot to stop remembering.' })
+      return
+    }
+
+    setSubmittingSuppress(true)
+    try {
+      const result = await window.memory.doNotRememberThis({
+        content: suppressForm.content.trim(),
+        source_platform: suppressForm.sourcePlatform.trim() || null,
+        source_excerpt: suppressForm.sourceExcerpt.trim() || null,
+        sensitivity_level: suppressForm.sensitivityLevel,
+        reason: suppressForm.reason.trim() || 'User explicitly chose not to remember this',
+      })
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to create suppression rule')
+      }
+
+      setSuppressForm(DEFAULT_SUPPRESS_FORM)
+      updateMessage({ type: 'success', text: 'Suppression rule saved locally.' })
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to save suppression rule' })
+    } finally {
+      setSubmittingSuppress(false)
+    }
+  }
+
+  const handleToggleCapture = async (): Promise<void> => {
+    try {
+      const result = capturePaused
+        ? await window.memory.resumeCapture('Resumed from local memory controls')
+        : await window.memory.pauseCapture('Paused from local memory controls')
+
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Failed to update capture state')
+      }
+
+      setCapturePaused(result.data.paused)
+      updateMessage({
+        type: 'success',
+        text: result.data.paused ? 'Local memory capture paused.' : 'Local memory capture resumed.',
+      })
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to update capture state' })
+    }
+  }
+
+  const handleDeleteMemory = async (id: string): Promise<void> => {
+    try {
+      const result = await window.memory.delete(id)
+      if (!result.success || !result.data?.deleted) {
+        throw new Error(result.error || 'Failed to delete memory')
+      }
+      if (editingId === id) {
+        setEditingId(null)
+        setEditDraft(null)
+      }
+      updateMessage({ type: 'success', text: 'Memory deleted.' })
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to delete memory' })
+    }
+  }
+
+  const handleDeleteBySource = async (): Promise<void> => {
+    if (!filters.sourcePlatform.trim()) {
+      updateMessage({ type: 'error', text: 'Choose or type a source platform first to bulk delete by source.' })
+      return
+    }
+
+    setBulkDeletingSource(true)
+    try {
+      const result = await window.memory.deleteBySource(filters.sourcePlatform.trim())
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Failed to delete memories by source')
+      }
+      updateMessage({
+        type: 'success',
+        text: `Deleted ${result.data.deletedCount} memories from source "${filters.sourcePlatform.trim()}".`,
+      })
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to delete by source' })
+    } finally {
+      setBulkDeletingSource(false)
+    }
+  }
+
+  const startEditing = (memory: ExplainedLocalMemoryItem) => {
+    setEditingId(memory.id)
+    setEditDraft(buildEditDraft(memory))
+  }
+
+  const handleSaveEdit = async (): Promise<void> => {
+    if (!editingId || !editDraft) return
+
+    setSavingId(editingId)
+    try {
+      const result = await window.memory.update(editingId, {
+        content: editDraft.content.trim(),
+        memory_type: editDraft.memory_type.trim(),
+        source_platform: editDraft.source_platform.trim() || null,
+        source_excerpt: editDraft.source_excerpt.trim() || null,
+        confidence: parseNumericInput(editDraft.confidence),
+        importance: parseNumericInput(editDraft.importance),
+        sensitivity_level: editDraft.sensitivity_level,
+        retention_until: fromDatetimeLocalValue(editDraft.retention_until),
+        status: editDraft.status,
+        why_stored: editDraft.why_stored.trim() || null,
+        conflict_state: editDraft.conflict_state,
+        conflict_notes: editDraft.conflict_notes.trim() || null,
+      })
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to update memory')
+      }
+
+      updateMessage({ type: 'success', text: 'Memory updated.' })
+      setEditingId(null)
+      setEditDraft(null)
+      await refreshAll(filters, true)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to update memory' })
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const handleLoadEvents = async (memoryId: string): Promise<void> => {
+    if (eventMemoryId === memoryId) {
+      setEventMemoryId(null)
+      return
+    }
+
+    setLoadingEventsId(memoryId)
+    try {
+      if (!events[memoryId]) {
+        const result = await window.memory.listEvents(memoryId)
+        if (!result.success || !result.data) {
+          throw new Error(result.error || 'Failed to load memory history')
+        }
+        setEvents((current) => ({ ...current, [memoryId]: result.data ?? [] }))
+      }
+      setEventMemoryId(memoryId)
+    } catch (error) {
+      updateMessage({ type: 'error', text: error instanceof Error ? error.message : 'Failed to load memory history' })
+    } finally {
+      setLoadingEventsId(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+        <div className="flex items-center justify-center py-10 text-[var(--text-muted)]">
+          <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+          Loading local memory controls...
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <Brain className="w-5 h-5 text-[var(--primary)]" />
+              <h4 className="text-[14px] font-semibold text-[var(--text-primary)]">Local Memory Controls</h4>
+            </div>
+            <p className="text-[12px] text-[var(--text-muted)] mt-1 leading-relaxed">
+              Control what memU bot stores locally, inspect why an item was retrieved, and clean up stale or sensitive memory without relying on cloud memory services.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`px-2.5 py-1 rounded-full text-[11px] font-medium ${capturePaused ? 'bg-amber-500/10 text-amber-600 dark:text-amber-300' : 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'}`}>
+              {capturePaused ? 'Capture paused' : 'Capture active'}
+            </span>
+            <button
+              onClick={handleToggleCapture}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-card)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] hover:border-[var(--primary)] transition-all"
+            >
+              {capturePaused ? <PlayCircle className="w-4 h-4" /> : <PauseCircle className="w-4 h-4" />}
+              {capturePaused ? 'Resume memory' : 'Pause memory'}
+            </button>
+            <button
+              onClick={() => void refreshAll(filters, true)}
+              disabled={refreshing}
+              className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-card)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] hover:border-[var(--primary)] transition-all disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+              Refresh
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm space-y-3">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="w-4 h-4 text-emerald-500" />
+            <h5 className="text-[13px] font-medium text-[var(--text-primary)]">Remember this</h5>
+          </div>
+          <textarea
+            value={rememberForm.content}
+            onChange={(event) => setRememberForm((current) => ({ ...current, content: event.target.value }))}
+            rows={4}
+            placeholder="Store a local memory note, preference, fact, or project detail..."
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <div className="grid gap-3 md:grid-cols-2">
+            <input
+              value={rememberForm.memoryType}
+              onChange={(event) => setRememberForm((current) => ({ ...current, memoryType: event.target.value }))}
+              placeholder="Type (manual_note, preference, fact...)"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+            <input
+              value={rememberForm.sourcePlatform}
+              onChange={(event) => setRememberForm((current) => ({ ...current, sourcePlatform: event.target.value }))}
+              placeholder="Source platform (local, slack, telegram...)"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+            <select
+              value={rememberForm.sensitivityLevel}
+              onChange={(event) => setRememberForm((current) => ({ ...current, sensitivityLevel: event.target.value as MemorySensitivityLevel }))}
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            >
+              <option value="normal">Normal</option>
+              <option value="work">Work</option>
+              <option value="sensitive">Sensitive</option>
+            </select>
+            <input
+              value={rememberForm.retentionDays}
+              onChange={(event) => setRememberForm((current) => ({ ...current, retentionDays: event.target.value }))}
+              placeholder="Retention days (blank = default)"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+            <input
+              value={rememberForm.confidence}
+              onChange={(event) => setRememberForm((current) => ({ ...current, confidence: event.target.value }))}
+              placeholder="Confidence 0-1"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+            <input
+              value={rememberForm.importance}
+              onChange={(event) => setRememberForm((current) => ({ ...current, importance: event.target.value }))}
+              placeholder="Importance 0-1"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+          </div>
+          <input
+            value={rememberForm.sourceExcerpt}
+            onChange={(event) => setRememberForm((current) => ({ ...current, sourceExcerpt: event.target.value }))}
+            placeholder="Source excerpt (optional)"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <input
+            value={rememberForm.whyStored}
+            onChange={(event) => setRememberForm((current) => ({ ...current, whyStored: event.target.value }))}
+            placeholder="Why should this memory be kept?"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <button
+            onClick={() => void handleRememberSubmit()}
+            disabled={submittingRemember}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-xl text-[13px] text-white transition-all disabled:opacity-50"
+            style={{ background: 'var(--primary-gradient)', boxShadow: 'var(--shadow-primary)' }}
+          >
+            <Save className="w-4 h-4" />
+            {submittingRemember ? 'Saving...' : 'Save local memory'}
+          </button>
+        </div>
+
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm space-y-3">
+          <div className="flex items-center gap-2">
+            <Ban className="w-4 h-4 text-amber-500" />
+            <h5 className="text-[13px] font-medium text-[var(--text-primary)]">Do not remember this</h5>
+          </div>
+          <textarea
+            value={suppressForm.content}
+            onChange={(event) => setSuppressForm((current) => ({ ...current, content: event.target.value }))}
+            rows={4}
+            placeholder="Enter content that should be suppressed from local memory..."
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <div className="grid gap-3 md:grid-cols-2">
+            <input
+              value={suppressForm.sourcePlatform}
+              onChange={(event) => setSuppressForm((current) => ({ ...current, sourcePlatform: event.target.value }))}
+              placeholder="Source platform"
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            />
+            <select
+              value={suppressForm.sensitivityLevel}
+              onChange={(event) => setSuppressForm((current) => ({ ...current, sensitivityLevel: event.target.value as MemorySensitivityLevel }))}
+              className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+            >
+              <option value="normal">Normal</option>
+              <option value="work">Work</option>
+              <option value="sensitive">Sensitive</option>
+            </select>
+          </div>
+          <input
+            value={suppressForm.sourceExcerpt}
+            onChange={(event) => setSuppressForm((current) => ({ ...current, sourceExcerpt: event.target.value }))}
+            placeholder="Source excerpt (optional)"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <input
+            value={suppressForm.reason}
+            onChange={(event) => setSuppressForm((current) => ({ ...current, reason: event.target.value }))}
+            placeholder="Reason for suppression"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <button
+            onClick={() => void handleSuppressSubmit()}
+            disabled={submittingSuppress}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-amber-500/10 border border-amber-500/20 text-[13px] text-amber-600 dark:text-amber-300 hover:bg-amber-500/20 transition-all disabled:opacity-50"
+          >
+            <ShieldAlert className="w-4 h-4" />
+            {submittingSuppress ? 'Saving...' : 'Create suppression rule'}
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm space-y-4">
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-[var(--primary)]" />
+          <h5 className="text-[13px] font-medium text-[var(--text-primary)]">Search and govern local memory</h5>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="xl:col-span-2">
+            <div className="relative">
+              <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+              <input
+                value={filters.query}
+                onChange={(event) => setFilters((current) => ({ ...current, query: event.target.value }))}
+                placeholder="Search content, source, reason, or memory type"
+                className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] pl-9 pr-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+              />
+            </div>
+          </div>
+          <input
+            value={filters.memoryType}
+            onChange={(event) => setFilters((current) => ({ ...current, memoryType: event.target.value }))}
+            placeholder="Filter by type"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <input
+            value={filters.sourcePlatform}
+            onChange={(event) => setFilters((current) => ({ ...current, sourcePlatform: event.target.value }))}
+            placeholder="Filter by source"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <select
+            value={filters.sensitivityLevel}
+            onChange={(event) => setFilters((current) => ({ ...current, sensitivityLevel: event.target.value as '' | MemorySensitivityLevel }))}
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          >
+            <option value="">All sensitivity levels</option>
+            <option value="normal">Normal</option>
+            <option value="work">Work</option>
+            <option value="sensitive">Sensitive</option>
+          </select>
+          <select
+            value={filters.conflictState}
+            onChange={(event) => setFilters((current) => ({ ...current, conflictState: event.target.value as '' | MemoryConflictState }))}
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          >
+            <option value="">All conflict states</option>
+            <option value="none">No conflict</option>
+            <option value="potential">Potential conflict</option>
+            <option value="confirmed">Confirmed conflict</option>
+          </select>
+          <input
+            value={filters.minConfidence}
+            onChange={(event) => setFilters((current) => ({ ...current, minConfidence: event.target.value }))}
+            placeholder="Min confidence"
+            className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+          />
+          <div className="flex flex-wrap items-center gap-3 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2">
+            <label className="inline-flex items-center gap-2 text-[12px] text-[var(--text-primary)]">
+              <input
+                type="checkbox"
+                checked={filters.includeArchived}
+                onChange={(event) => setFilters((current) => ({ ...current, includeArchived: event.target.checked }))}
+              />
+              Include archived
+            </label>
+            <label className="inline-flex items-center gap-2 text-[12px] text-[var(--text-primary)]">
+              <input
+                type="checkbox"
+                checked={filters.excludeSensitive}
+                onChange={(event) => setFilters((current) => ({ ...current, excludeSensitive: event.target.checked }))}
+              />
+              Exclude sensitive
+            </label>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={handleDeleteBySource}
+            disabled={bulkDeletingSource}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-[13px] text-red-600 dark:text-red-300 hover:bg-red-500/20 transition-all disabled:opacity-50"
+          >
+            <Trash2 className="w-4 h-4" />
+            {bulkDeletingSource ? 'Deleting...' : 'Delete all from current source filter'}
+          </button>
+          <button
+            onClick={() => setFilters(DEFAULT_FILTERS)}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-card)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)] hover:border-[var(--primary)] transition-all"
+          >
+            <Database className="w-4 h-4" />
+            Reset filters
+          </button>
+        </div>
+
+        <div className="text-[12px] text-[var(--text-muted)]">
+          Showing {activeMemories.length} local memor{activeMemories.length === 1 ? 'y' : 'ies'}
+          {filters.query.trim() ? ' ranked by retrieval score and explanation' : ' with provenance, retention, and conflict details'}.
+        </div>
+
+        <div className="space-y-3">
+          {activeMemories.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-[var(--border-color)] px-4 py-8 text-center text-[13px] text-[var(--text-muted)]">
+              No local memories matched the current filters.
+            </div>
+          ) : (
+            activeMemories.map((memory) => {
+              const searchMeta = searchResults?.find((entry) => entry.memory.id === memory.id)
+              const isEditing = editingId === memory.id && !!editDraft
+              const isEventsOpen = eventMemoryId === memory.id
+              const memoryEvents = events[memory.id] ?? []
+
+              return (
+                <div
+                  key={memory.id}
+                  className="rounded-2xl border border-[var(--glass-border)] bg-[var(--bg-card)]/70 px-4 py-4 shadow-sm"
+                >
+                  <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+                    <div className="space-y-2 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">{memory.memory_type}</span>
+                        <span className={`px-2 py-1 rounded-full text-[11px] ${sensitivityBadgeClass(memory.sensitivity_level)}`}>
+                          {memory.sensitivity_level}
+                        </span>
+                        <span className={`px-2 py-1 rounded-full text-[11px] ${conflictBadgeClass(memory.conflict_state)}`}>
+                          {memory.conflict_state} conflict
+                        </span>
+                        <span className="px-2 py-1 rounded-full text-[11px] bg-slate-500/10 text-slate-600 dark:text-slate-300 border border-slate-500/20">
+                          {memory.status}
+                        </span>
+                        <span className="px-2 py-1 rounded-full text-[11px] bg-blue-500/10 text-blue-600 dark:text-blue-300 border border-blue-500/20">
+                          {memory.user_control}
+                        </span>
+                      </div>
+                      <p className="text-[14px] text-[var(--text-primary)] whitespace-pre-wrap leading-relaxed">{memory.content}</p>
+                      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4 text-[12px] text-[var(--text-muted)]">
+                        <div>Source: <span className="text-[var(--text-primary)]">{memory.source_platform ?? 'unknown'}</span></div>
+                        <div>Confidence: <span className="text-[var(--text-primary)]">{memory.confidence.toFixed(2)}</span></div>
+                        <div>Importance: <span className="text-[var(--text-primary)]">{memory.importance.toFixed(2)}</span></div>
+                        <div>Retention: <span className="text-[var(--text-primary)]">{formatRetention(memory.retention_until)}</span></div>
+                      </div>
+                      <div className="text-[12px] text-[var(--text-muted)]">
+                        Why stored: <span className="text-[var(--text-primary)]">{memory.explanation.provenance.why_stored ?? 'No reason recorded'}</span>
+                      </div>
+                      {memory.explanation.provenance.source_excerpt && (
+                        <div className="text-[12px] text-[var(--text-muted)]">
+                          Source excerpt: <span className="text-[var(--text-primary)]">{memory.explanation.provenance.source_excerpt}</span>
+                        </div>
+                      )}
+                      {memory.conflict_notes && (
+                        <div className="text-[12px] text-amber-600 dark:text-amber-300">
+                          Conflict notes: {memory.conflict_notes}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        onClick={() => startEditing(memory)}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[12px] text-[var(--text-primary)] hover:border-[var(--primary)] transition-all"
+                      >
+                        <Pencil className="w-4 h-4" />
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => void handleLoadEvents(memory.id)}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[12px] text-[var(--text-primary)] hover:border-[var(--primary)] transition-all"
+                      >
+                        <History className="w-4 h-4" />
+                        {loadingEventsId === memory.id ? 'Loading...' : 'History'}
+                      </button>
+                      <button
+                        onClick={() => {
+                          setSuppressForm((current) => ({
+                            ...current,
+                            content: memory.content,
+                            sourcePlatform: memory.source_platform ?? '',
+                            sourceExcerpt: memory.source_excerpt ?? '',
+                            sensitivityLevel: memory.sensitivity_level,
+                          }))
+                          window.scrollTo({ top: 0, behavior: 'smooth' })
+                        }}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-amber-500/10 border border-amber-500/20 text-[12px] text-amber-600 dark:text-amber-300 hover:bg-amber-500/20 transition-all"
+                      >
+                        <Ban className="w-4 h-4" />
+                        Don’t remember
+                      </button>
+                      <button
+                        onClick={() => void handleDeleteMemory(memory.id)}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/20 text-[12px] text-red-600 dark:text-red-300 hover:bg-red-500/20 transition-all"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+
+                  {searchMeta && (
+                    <div className="mt-3 rounded-xl bg-[var(--glass-bg)] border border-[var(--glass-border)] p-3">
+                      <div className="flex items-center gap-2 text-[12px] text-[var(--text-primary)] font-medium">
+                        <Eye className="w-4 h-4 text-[var(--primary)]" />
+                        Why this memory was retrieved
+                      </div>
+                      <div className="mt-2 text-[12px] text-[var(--text-muted)]">
+                        Score: <span className="text-[var(--text-primary)] font-medium">{searchMeta.retrieval_explanation.score.toFixed(3)}</span>
+                      </div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {searchMeta.retrieval_explanation.matched_fields.map((field: MemoryMatchField, index: number) => (
+                          <span
+                            key={`${memory.id}-${field.field}-${index}`}
+                            className="px-2 py-1 rounded-full bg-[var(--bg-input)] border border-[var(--border-color)] text-[11px] text-[var(--text-primary)]"
+                            title={field.value_excerpt}
+                          >
+                            {field.field}: {field.matched_terms.join(', ')}
+                          </span>
+                        ))}
+                      </div>
+                      <ul className="mt-2 space-y-1 text-[12px] text-[var(--text-muted)]">
+                        {searchMeta.retrieval_explanation.score_reasons.map((reason: string, index: number) => (
+                          <li key={`${memory.id}-reason-${index}`}>• {reason}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {isEditing && editDraft && (
+                    <div className="mt-3 rounded-xl bg-[var(--glass-bg)] border border-[var(--glass-border)] p-4 space-y-3">
+                      <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-primary)]">
+                        <Pencil className="w-4 h-4 text-[var(--primary)]" />
+                        Edit memory
+                      </div>
+                      <textarea
+                        value={editDraft.content}
+                        onChange={(event) => setEditDraft((current) => current ? { ...current, content: event.target.value } : current)}
+                        rows={3}
+                        className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]"
+                      />
+                      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        <input value={editDraft.memory_type} onChange={(event) => setEditDraft((current) => current ? { ...current, memory_type: event.target.value } : current)} className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <input value={editDraft.source_platform} onChange={(event) => setEditDraft((current) => current ? { ...current, source_platform: event.target.value } : current)} className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <select value={editDraft.sensitivity_level} onChange={(event) => setEditDraft((current) => current ? { ...current, sensitivity_level: event.target.value as MemorySensitivityLevel } : current)} className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]">
+                          <option value="normal">Normal</option>
+                          <option value="work">Work</option>
+                          <option value="sensitive">Sensitive</option>
+                        </select>
+                        <input value={editDraft.confidence} onChange={(event) => setEditDraft((current) => current ? { ...current, confidence: event.target.value } : current)} placeholder="Confidence" className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <input value={editDraft.importance} onChange={(event) => setEditDraft((current) => current ? { ...current, importance: event.target.value } : current)} placeholder="Importance" className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <select value={editDraft.status} onChange={(event) => setEditDraft((current) => current ? { ...current, status: event.target.value as MemoryStatus } : current)} className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]">
+                          <option value="active">active</option>
+                          <option value="archived">archived</option>
+                          <option value="deleted">deleted</option>
+                        </select>
+                        <select value={editDraft.conflict_state} onChange={(event) => setEditDraft((current) => current ? { ...current, conflict_state: event.target.value as MemoryConflictState } : current)} className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]">
+                          <option value="none">none</option>
+                          <option value="potential">potential</option>
+                          <option value="confirmed">confirmed</option>
+                        </select>
+                        <input value={editDraft.retention_until} onChange={(event) => setEditDraft((current) => current ? { ...current, retention_until: event.target.value } : current)} type="datetime-local" className="w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <input value={editDraft.source_excerpt} onChange={(event) => setEditDraft((current) => current ? { ...current, source_excerpt: event.target.value } : current)} placeholder="Source excerpt" className="md:col-span-2 xl:col-span-3 w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <input value={editDraft.why_stored} onChange={(event) => setEditDraft((current) => current ? { ...current, why_stored: event.target.value } : current)} placeholder="Why stored" className="md:col-span-2 xl:col-span-3 w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                        <textarea value={editDraft.conflict_notes} onChange={(event) => setEditDraft((current) => current ? { ...current, conflict_notes: event.target.value } : current)} rows={2} placeholder="Conflict notes" className="md:col-span-2 xl:col-span-3 w-full rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--primary)]" />
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          onClick={() => void handleSaveEdit()}
+                          disabled={savingId === memory.id}
+                          className="inline-flex items-center gap-2 px-3 py-2 rounded-xl text-[13px] text-white transition-all disabled:opacity-50"
+                          style={{ background: 'var(--primary-gradient)', boxShadow: 'var(--shadow-primary)' }}
+                        >
+                          <Save className="w-4 h-4" />
+                          {savingId === memory.id ? 'Saving...' : 'Save changes'}
+                        </button>
+                        <button
+                          onClick={() => {
+                            setEditingId(null)
+                            setEditDraft(null)
+                          }}
+                          className="inline-flex items-center gap-2 px-3 py-2 rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] text-[13px] text-[var(--text-primary)]"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {isEventsOpen && (
+                    <div className="mt-3 rounded-xl bg-[var(--glass-bg)] border border-[var(--glass-border)] p-4">
+                      <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-primary)]">
+                        <FileClock className="w-4 h-4 text-[var(--primary)]" />
+                        Memory history
+                      </div>
+                      {memoryEvents.length === 0 ? (
+                        <div className="mt-2 text-[12px] text-[var(--text-muted)]">
+                          No history events recorded for this memory yet.
+                        </div>
+                      ) : (
+                        <div className="mt-3 space-y-2">
+                          {memoryEvents.map((event) => (
+                            <div key={event.id} className="rounded-xl bg-[var(--bg-input)] border border-[var(--border-color)] px-3 py-3">
+                              <div className="flex flex-wrap items-center gap-2 text-[12px]">
+                                <span className="font-medium text-[var(--text-primary)]">{event.event_type}</span>
+                                <span className="text-[var(--text-muted)]">by {event.actor}</span>
+                                <span className="text-[var(--text-muted)]">{formatDateTime(event.created_at)}</span>
+                              </div>
+                              {event.reason && (
+                                <div className="mt-1 text-[12px] text-[var(--text-primary)]">{event.reason}</div>
+                              )}
+                              {event.payload_json && (
+                                <pre className="mt-2 whitespace-pre-wrap break-all text-[11px] text-[var(--text-muted)]">{event.payload_json}</pre>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-primary)]">
+            <ShieldEllipsis className="w-4 h-4 text-[var(--primary)]" />
+            Privacy model
+          </div>
+          <p className="mt-2 text-[12px] text-[var(--text-muted)] leading-relaxed">
+            Sensitive items get shorter default retention, can be excluded from search, and can be bulk-deleted by source.
+          </p>
+        </div>
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-primary)]">
+            <Clock3 className="w-4 h-4 text-[var(--primary)]" />
+            Quality controls
+          </div>
+          <p className="mt-2 text-[12px] text-[var(--text-muted)] leading-relaxed">
+            Retrieval explanations surface confidence, importance, time decay, and conflict penalties so low-quality memory is easier to spot.
+          </p>
+        </div>
+        <div className="p-4 rounded-2xl bg-[var(--glass-bg)] backdrop-blur-xl border border-[var(--glass-border)] shadow-sm">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--text-primary)]">
+            {filters.excludeSensitive ? <EyeOff className="w-4 h-4 text-[var(--primary)]" /> : <Eye className="w-4 h-4 text-[var(--primary)]" />}
+            Retrieval controls
+          </div>
+          <p className="mt-2 text-[12px] text-[var(--text-muted)] leading-relaxed">
+            Use type, source, sensitivity, archived-state, and confidence filters to control not just what gets stored, but what the assistant is allowed to use.
+          </p>
+        </div>
+      </div>
+
+      <MessageDisplay message={message} />
+    </div>
+  )
+}

--- a/src/renderer/src/components/Settings/DataSettings/memu.impl.tsx
+++ b/src/renderer/src/components/Settings/DataSettings/memu.impl.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TelegramIcon, DiscordIcon, SlackIcon, FeishuIcon } from '../../Icons/AppIcons'
 import { MessageDisplay, LoadingSpinner, formatBytes } from '../shared'
+import { LocalMemorySettings } from './LocalMemorySettings'
 
 interface StorageFolder {
   name: string
@@ -215,6 +216,8 @@ export function MemuDataSettings(): JSX.Element {
             </button>
           </div>
         </div>
+
+        <LocalMemorySettings />
 
         {/* Message */}
         <MessageDisplay message={message} />

--- a/src/renderer/src/components/Settings/ObservabilitySettings.tsx
+++ b/src/renderer/src/components/Settings/ObservabilitySettings.tsx
@@ -457,7 +457,7 @@ function TraceRow({ trace, expanded, onToggle }: { trace: TraceEntry; expanded: 
           {trace.spans[0]?.tokenUsage && (
             <div className="flex items-center gap-2 pl-3 pt-1 text-[10px] text-amber-500/80 border-t border-[var(--border-color)]">
               <Zap className="w-3 h-3" />
-              <span>{t('settings.observability.traces.totalTokens', { count: trace.spans[0].tokenUsage.total.toLocaleString() })}</span>
+              <span>{t('settings.observability.traces.totalTokens', { count: trace.spans[0].tokenUsage.total })}</span>
               <span className="text-[var(--text-muted)] opacity-50">
                 ({t('settings.observability.traces.tokenBreakdown', { input: trace.spans[0].tokenUsage.input.toLocaleString(), output: trace.spans[0].tokenUsage.output.toLocaleString() })})
               </span>
@@ -494,7 +494,7 @@ function MetricsDashboard({ metrics }: { metrics: MetricsSummary }): JSX.Element
         <MetricCard
           label={t('settings.observability.metrics.llmCalls')}
           value={metrics.llm.callCount.toString()}
-          sub={t('settings.observability.metrics.tokens', { count: (metrics.llm.totalInputTokens + metrics.llm.totalOutputTokens).toLocaleString() })}
+          sub={t('settings.observability.metrics.tokens', { count: metrics.llm.totalInputTokens + metrics.llm.totalOutputTokens })}
           color="amber"
         />
       </div>

--- a/src/renderer/src/components/Settings/SettingsView/memu.impl.tsx
+++ b/src/renderer/src/components/Settings/SettingsView/memu.impl.tsx
@@ -72,7 +72,7 @@ export function MemuSettingsView(): JSX.Element {
         <div id={SETTINGS_BAR_PORTAL_ID} />
 
         <div className="flex-1 overflow-y-auto">
-          <div className={`mx-auto py-6 px-5 pb-24 ${activeTab === 'observability' ? 'max-w-2xl' : 'max-w-lg'}`}>
+          <div className={`mx-auto py-6 px-5 pb-24 ${activeTab === 'observability' ? 'max-w-2xl' : activeTab === 'data' ? 'max-w-6xl' : 'max-w-lg'}`}>
             {activeTab === 'general' && <GeneralSettings />}
             {activeTab === 'platforms' && <PlatformSettings />}
             {activeTab === 'security' && <SecuritySettings />}


### PR DESCRIPTION
## Summary
- add a local controlled-memory provider that works without remote memU configuration
- expose memory control APIs through IPC and preload for pause/resume, manual remember, suppression, edit/delete, history, and retrieval explanations
- add a settings UI for inspecting and managing local memory entries, including provenance, retention, conflict state, and retrieval reasons
- fall back to local controlled memory retrieval when remote memU is not configured

## Why
This complements the existing memory fallback work by making local memory usable and inspectable from the product layer. It gives users direct control over what is stored locally and what can be retrieved, without requiring cloud memory services.

## Relationship To #33
- `#33` is a narrow hardening PR for retrieval correctness and topic-scoring fallbacks
- this PR is the larger product-surface PR that exposes local controlled-memory capabilities end to end
- the two PRs are complementary, but intentionally separate so the smaller fallback fix can be reviewed and merged independently
- this PR does not supersede `#33`; it builds out the broader local-memory management surface

## Included functionality
- pause / resume local memory capture
- manually remember an item
- mark content as "don't remember"
- filterable local memory list
- provenance / why stored / retention / conflict display
- "Why this memory was retrieved" explanation display
- single-item edit / delete
- bulk delete by source
- memory history view

## Scope
This PR is intentionally scoped as a complete local controlled-memory management surface, so it includes:
- backend provider and storage changes
- IPC and preload bridge changes
- settings UI changes

It intentionally excludes unrelated notes and package metadata changes that existed in my fork.

## Reviewer Notes
- the main review question here is whether memU should support a fully local, user-controllable memory-management path in the product surface
- the backend and UI are included together because the UI depends on the new local memory control APIs
- I left this PR as draft to make it easier to discuss scope and desired split before asking for final review

## Validation
- `npm run typecheck`
- manually verified the intended surface on this branch: pause/resume, remember-this, don't-remember, filtered list view, retrieval explanation, single-item edit/delete, delete-by-source, and memory history
- verified branch is based on `upstream/main` and excludes unrelated notes / package metadata changes

## Risks / Tradeoffs
- this is materially larger than `#33`, so I expect review attention to focus on scope and product fit more than on individual line changes
- there may still be unrelated upstream failures outside this branch's changed paths; this PR is not intended to fix those existing issues
