### PR TITLE
add builtin notion skill

### DIFF
--- a/src/main/builtin-skills/notion-assistant/SKILL.md
+++ b/src/main/builtin-skills/notion-assistant/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: Notion Assistant
+description: Guide for working with Notion pages and databases for search, summarization, drafting, and structured updates
+---
+
+# Notion Assistant Skill
+
+Use this skill when the user asks to work with Notion content, such as:
+- Searching or finding pages, notes, docs, tasks, or meeting records in Notion
+- Summarizing or extracting action items from Notion content
+- Drafting or updating pages, project docs, or meeting notes in Notion
+- Creating or editing database entries such as tasks, projects, bugs, CRM records, or knowledge-base items
+- Organizing existing Notion content into cleaner structures
+
+## Workflow
+
+1. Identify whether the request is about a Notion page, a database, or both.
+2. Retrieve the minimum relevant content first. Do not load large amounts of unrelated Notion content.
+3. Confirm the target operation mentally before making changes: search, summarize, draft, update, move, or structure.
+4. Prefer small, reversible updates when editing an existing workspace.
+5. After changes, report what was updated and call out any assumptions you made.
+
+## Working Style
+
+- Preserve the user's existing structure, naming, and writing style unless they ask for a redesign.
+- Keep summaries concise and action-oriented.
+- When converting unstructured notes into structured content, prefer sections such as:
+  - Summary
+  - Decisions
+  - Open Questions
+  - Action Items
+- For task or project databases, keep fields normalized and avoid inventing statuses or properties unless the surrounding data makes them obvious.
+
+## Common Patterns
+
+### Summarize a page
+
+- Extract the smallest relevant section set.
+- Produce a short summary first.
+- If useful, add:
+  - Key decisions
+  - Risks
+  - Next steps
+
+### Turn notes into a clean doc
+
+- Keep the original meaning.
+- Remove obvious duplication.
+- Group content into a small number of sections.
+- Preserve names, dates, links, and owners whenever present.
+
+### Update a database
+
+- Reuse existing properties and option values when possible.
+- If a requested property is missing, prefer flagging the mismatch instead of inventing a schema change.
+- When adding records, make titles specific and concise.
+
+### Prepare meeting notes
+
+- Use a structure like:
+  - Agenda
+  - Discussion
+  - Decisions
+  - Action Items
+- For action items, include owner and timing when available from context.
+
+## Guardrails
+
+- Do not fabricate page contents, IDs, database schema, or teammate names.
+- If the request depends on specific workspace content that has not been provided or retrieved, fetch it before answering.
+- If an edit could overwrite important structure, prefer a narrower change.
+- When the user asks for a broad cleanup, preserve the original information and improve organization rather than rewriting aggressively.

--- a/src/main/services/agent/prompt-builder.ts
+++ b/src/main/services/agent/prompt-builder.ts
@@ -173,7 +173,7 @@ Services should call the local API at http://127.0.0.1:31415/api/v1/invoke to re
 Example: Instead of directly calling \`bash\` with a command, first say "Let me check the current directory structure." then call the tool.`
 
   // Load builtin skills (bundled with app)
-  const builtinSkillNames = ['service-creator', 'keynote-creator']
+  const builtinSkillNames = ['service-creator', 'keynote-creator', 'notion-assistant']
   for (const skillName of builtinSkillNames) {
     try {
       const builtinSkillsDir = path.join(__dirname, '../../builtin-skills')


### PR DESCRIPTION
## What changed

- add a new builtin `Notion Assistant` skill
- register `notion-assistant` in the builtin skill list so it is loaded into the agent prompt

## Why

memU already includes builtin skills for specific workflows, but it did not have a builtin skill for common Notion tasks. This adds a lightweight prompt guide for Notion-related requests such as searching pages, summarizing content, drafting notes, and updating structured records.

## Impact

- improves agent guidance for Notion page and database workflows
- keeps the change small and self-contained
- does not change runtime behavior outside of prompt construction

## Validation

- ran `npm run typecheck`
